### PR TITLE
Update Dockerfile

### DIFF
--- a/.github/workflows/build-pr-tests.yaml
+++ b/.github/workflows/build-pr-tests.yaml
@@ -2,7 +2,7 @@ name: Build tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, reopened, edited]
     branches:
       - main
     paths:

--- a/.github/workflows/build-pr-tests.yaml
+++ b/.github/workflows/build-pr-tests.yaml
@@ -1,23 +1,32 @@
 name: Build tests
 
 on:
-  pull_request_target:
-    branches: main
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - entrypoint.js
+  
+  push:
+    branches-ignore:
+      - main
+    tags-ignore:
+      - v*
     paths: 
     - Dockerfile
     - entrypoint.js
 
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      packages: read
-      contents: read
-      actions: read
-      statuses: write
-      checks: write
-      pull-requests: read
-      attestations: write
+
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -28,8 +37,6 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 1
-          ref: ${{ github.ref }}
-          persist-credentials: false
           
       -
         name: Set up Docker Buildx
@@ -49,21 +56,14 @@ jobs:
         continue-on-error: true
         run: echo ${{ steps.versions.outputs.GHOST_VERSION }} 
       -
-        name: Docker meta for workflow_dispatch
-        id: meta-workflow-dispatch
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-
-      -
         name: Build
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
-        id: build-and-push-workflow-dispatch
+        id: build-pr
         with:
           context: .
           platforms: linux/amd64
           cache-from: type=gha,mode=max
           cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
           push: false
           build-args: GHOST_VERSION=${{ steps.versions.outputs.GHOST_VERSION }}
           

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -39,4 +39,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4

--- a/.github/workflows/multi-build.yaml
+++ b/.github/workflows/multi-build.yaml
@@ -243,7 +243,7 @@ jobs:
         run: |
               docker buildx imagetools create \
                 $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-                --annotation='index:org.opencontainers.image.description="Ghost on Kubernetes by SREDevOps.org' \
+                --annotation='index:org.opencontainers.image.description="Ghost on Kubernetes by SREDevOps.org https://sredevops.org "' \
                   $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
 
       -

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ Temporary Items
 
 ***/*.local*
 docker-compose.yml
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 # Stage 1: Build Environment
 FROM node:iron-bookworm@sha256:786005cf39792f7046bcd66491056c26d2dbcc669c072d1a1e4ef4fcdddd26eb AS build-env
 
+USER node
 SHELL ["/bin/bash", "-c"]
 ENV NODE_ENV=production NPM_CONFIG_LOGLEVEL=info
 
@@ -30,7 +31,6 @@ RUN yarn config set network-timeout 60000 && \
 
 
 # RUN	npm i -g ghost-cli@latest || yarn global add ghost-cli@latest
-
 
 # Install Ghost with the specified version, using MySQL as the database, and configure it without prompts, stack traces, setup, and in the specified installation directory
 # RUN ghost install $GHOST_VERSION --dir $GHOST_INSTALL --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --color --process local || 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ ENV NODE_ENV=production DEBIAN_FRONTEND=noninteractive
 
 # Update sources and install libvips to build some dependencies later
 
-#USER root
-#RUN apt update && apt install --no-install-recommends --no-install-suggests -y libvips-dev 
+# USER root
+# RUN apt update && apt install --no-install-recommends --no-install-suggests -y libvips-dev 
+USER node
 
 # Install the latest version of Ghost CLI globally and config some workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 60000 && \
@@ -34,7 +35,7 @@ RUN mkdir -pv "$GHOST_INSTALL" && \
     chown node:node "$GHOST_INSTALL"
 
 # Switch to the "node" user
-USER node
+# USER node
 # Workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 180000 && \
       npm config set fetch-timeout 180000
@@ -50,14 +51,14 @@ RUN ghost install $GHOST_VERSION --dir $GHOST_INSTALL --db mysql --dbhost mysql 
 
 # Move the original content directory to a backup location, create a new content directory, set the correct ownership and permissions, and switch back to the "node" user
 RUN mv -v $GHOST_CONTENT $GHOST_CONTENT_ORIGINAL && \
-    mkdir -pv $GHOST_CONTENT && \
+    mkdir -v $GHOST_CONTENT && \
     chown -Rfv node:node $GHOST_CONTENT_ORIGINAL && \
     chown -Rfv node:node $GHOST_CONTENT && \
     chown -fv node:node $GHOST_INSTALL && \
-    chmod 1755 $GHOST_CONTENT
+    chmod -v 1755 $GHOST_CONTENT
 
 # Switch back to the "node" user
-#USER node
+# USER node
 
 # Stage 2: Final Image
 FROM gcr.io/distroless/nodejs20-debian12@sha256:08d0b6846a21812d07a537eff956acc1bc38a7440a838ce6730515f8d3cd5d9e AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,16 @@
 
 # Stage 1: Build Environment
 FROM node:iron-bookworm@sha256:786005cf39792f7046bcd66491056c26d2dbcc669c072d1a1e4ef4fcdddd26eb AS build-env
+USER root
+# Create a new user and group named "nonroot" with the UID 65532 and GID 65532, not a member of the root, sudo, and sys groups, and set the home directory to /home/nonroot.
+# This user is used to run the Ghost application in the container for security reasons.
+RUN groupadd -g 65532 nonroot && \
+    useradd -u 65532 -g 65532 -d /home/nonroot nonroot && \
+    usermod -aG nonroot nonroot && \
+    mkdir -pv /home/nonroot && \
+    chown -Rfv 65532:65532 /home/nonroot
 
-USER node
+USER nonroot
 SHELL ["/bin/bash", "-c"]
 ENV NODE_ENV=production NPM_CONFIG_LOGLEVEL=info
 
@@ -17,9 +25,8 @@ ENV GHOST_INSTALL=/home/nonroot/app/ghost
 ENV GHOST_CONTENT=/home/nonroot/app/ghost/content
 ENV GHOST_CONTENT_ORIGINAL=/home/nonroot/app/ghost/content.orig
 
-RUN mkdir -pv "$GHOST_INSTALL" || sudo mkdir -pv "$GHOST_INSTALL" && \
-    chown -Rfv 65532:65532 "$GHOST_INSTALL" || sudo chown -Rfv nonroot:nonroot "$GHOST_INSTALL"
-
+RUN mkdir -pv "$GHOST_INSTALL"
+    
 # Install the latest version of Ghost CLI globally and config some workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 60000 && \
     yarn config set inline-builds true && \
@@ -41,23 +48,22 @@ RUN npx ghost-cli install $GHOST_VERSION --dir $GHOST_INSTALL --db mysql --dbhos
 # Move the original content directory to a backup location, create a new content directory, set the correct ownership and permissions, and switch back to the "node" user
 RUN mv -v $GHOST_CONTENT $GHOST_CONTENT_ORIGINAL && \
     mkdir -v $GHOST_CONTENT && \
-    chown -Rfv nonroot:nobody $GHOST_CONTENT_ORIGINAL && \
-    chown -Rfv nonroot:nobody $GHOST_CONTENT && \
-    chown -fv nonroot:nobody $GHOST_INSTALL && \
+    # chown -Rfv 65532 $GHOST_CONTENT_ORIGINAL && \
+    # chown -Rfv 65532 $GHOST_CONTENT && \
+    # chown -fv 65532 $GHOST_INSTALL && \
     chmod -v 0775 $GHOST_CONTENT
 
 # Switch back to the "node" user
 # USER node
 
 # Stage 2: Final Image
-FROM gcr.io/distroless/nodejs20-debian12:nonroot
+FROM gcr.io/distroless/nodejs20-debian12
 
 # Set the installation directory and content directory for Ghost
 ENV GHOST_INSTALL_SRC=/home/nonroot/app/ghost
 ENV GHOST_INSTALL=/home/nonroot/app/ghost
 ENV GHOST_CONTENT=/home/nonroot/app/ghost/content
 ENV GHOST_CONTENT_ORIGINAL=/home/nonroot/app/ghost/content.orig
-
 USER nonroot
 
 # Copy the Ghost installation directory from the build environment to the final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Stage 1: Build Environment
 FROM node:iron-bookworm@sha256:786005cf39792f7046bcd66491056c26d2dbcc669c072d1a1e4ef4fcdddd26eb AS build-env
 
-ENV NODE_ENV=production DEBIAN_FRONTEND=noninteractive
+ENV NODE_ENV=production  NPM_CONFIG_LOGLEVEL=info
 
 # Update sources and install libvips to build some dependencies later
 
@@ -15,20 +15,20 @@ USER node
 # Install the latest version of Ghost CLI globally and config some workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 60000 && \
     yarn config set inline-builds true && \
-		npm config set fetch-timeout 60000 && \
+    npm config set fetch-timeout 60000 && \
     npm config set progress && \
     npm config set omit dev
 
 RUN	yarn global add ghost-cli@latest
 
 # Define the GHOST_VERSION build argument and set it as an environment variable
-ARG GHOST_VERSION
-ENV GHOST_VERSION=$GHOST_VERSION 
+ARG GHOST_VERSION 
+ENV GHOST_VERSION=$GHOST_VERSION  
 
 # Set the installation directory, content directory, and original content directory for Ghost
-ENV GHOST_INSTALL=/var/lib/ghost
-ENV GHOST_CONTENT=/var/lib/ghost/content
-ENV GHOST_CONTENT_ORIGINAL=/var/lib/ghost/content.orig
+ENV GHOST_INSTALL=/home/node/app/ghost
+ENV GHOST_CONTENT=/home/node/app/ghost/content
+ENV GHOST_CONTENT_ORIGINAL=/home/node/app/ghost/content.orig
 
 # Create the Ghost installation directory and set the owner to the "node" user
 RUN mkdir -pv "$GHOST_INSTALL" && \
@@ -38,7 +38,7 @@ RUN mkdir -pv "$GHOST_INSTALL" && \
 # USER node
 # Workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 180000 && \
-      npm config set fetch-timeout 180000
+    npm config set fetch-timeout 180000
   #yarn config set inline-builds true && \
   #npm config set progress && \
   #npm config set omit dev
@@ -55,7 +55,7 @@ RUN mv -v $GHOST_CONTENT $GHOST_CONTENT_ORIGINAL && \
     chown -Rfv node:node $GHOST_CONTENT_ORIGINAL && \
     chown -Rfv node:node $GHOST_CONTENT && \
     chown -fv node:node $GHOST_INSTALL && \
-    chmod -v 1755 $GHOST_CONTENT
+    chmod -v 1775 $GHOST_CONTENT
 
 # Switch back to the "node" user
 # USER node
@@ -64,9 +64,9 @@ RUN mv -v $GHOST_CONTENT $GHOST_CONTENT_ORIGINAL && \
 FROM gcr.io/distroless/nodejs20-debian12@sha256:08d0b6846a21812d07a537eff956acc1bc38a7440a838ce6730515f8d3cd5d9e AS runtime
 
 # Set the installation directory and content directory for Ghost
-ENV GHOST_INSTALL=/var/lib/ghost
-ENV GHOST_CONTENT=/var/lib/ghost/content
-ENV GHOST_CONTENT_ORIGINAL=/var/lib/ghost/content.orig
+ENV GHOST_INSTALL=/home/node/app/ghost
+ENV GHOST_CONTENT=/home/node/app/ghost/content
+ENV GHOST_CONTENT_ORIGINAL=/home/node/app/ghost/content.orig
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN mv -v $GHOST_CONTENT $GHOST_CONTENT_ORIGINAL && \
 # USER node
 
 # Stage 2: Final Image
-FROM gcr.io/distroless/nodejs20-debian12-nonroot
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
 
 # Set the installation directory and content directory for Ghost
 ENV GHOST_INSTALL_SRC=/home/nonroot/app/ghost

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Stage 1: Build Environment
 FROM node:iron-bookworm@sha256:786005cf39792f7046bcd66491056c26d2dbcc669c072d1a1e4ef4fcdddd26eb AS build-env
 
-ENV NODE_ENV=production  NPM_CONFIG_LOGLEVEL=info
+ENV NODE_ENV=production NPM_CONFIG_LOGLEVEL=info
 
 # Update sources and install libvips to build some dependencies later
 
@@ -19,7 +19,7 @@ RUN yarn config set network-timeout 60000 && \
     npm config set progress && \
     npm config set omit dev
 
-RUN	yarn global add ghost-cli@latest
+RUN	yarn global add ghost-cli@latest || npm i -g ghost-cli@latest
 
 # Define the GHOST_VERSION build argument and set it as an environment variable
 ARG GHOST_VERSION 
@@ -39,12 +39,12 @@ RUN mkdir -pv "$GHOST_INSTALL" && \
 # Workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 180000 && \
     npm config set fetch-timeout 180000
-  #yarn config set inline-builds true && \
-  #npm config set progress && \
-  #npm config set omit dev
+    yarn config set inline-builds true && \
+    npm config set progress && \
+    npm config set omit dev
 
 # Install Ghost with the specified version, using MySQL as the database, and configure it without prompts, stack traces, setup, and in the specified installation directory
-RUN ghost install $GHOST_VERSION --dir $GHOST_INSTALL --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --color --process local
+RUN ghost install $GHOST_VERSION --dir $GHOST_INSTALL --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --color --process local || npx ghost-cli install $GHOST_VERSION --dir $GHOST_INSTALL --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --color --process local
 
 # Switch back to the root user
 #USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -pv "$GHOST_INSTALL" && \
 # USER node
 # Workarounds to build arm64 version in Github without timeout failures
 RUN yarn config set network-timeout 180000 && \
-    npm config set fetch-timeout 180000
+    npm config set fetch-timeout 180000 && \
     yarn config set inline-builds true && \
     npm config set progress && \
     npm config set omit dev

--- a/deploy/02-pvc.yaml
+++ b/deploy/02-pvc.yaml
@@ -12,10 +12,10 @@ metadata:
     app.kubernetes.io/part-of: ghost-on-kubernetes
     app.kubernetes.io/managed-by: sredevopsorg
 spec:
-  storageClassName: longhorn-rwx # Change this to your storageClassName
+  storageClassName: local-path # Change this to your storageClassName
   volumeMode: Filesystem
   accessModes:
-  - ReadWriteMany # Change this to your accessModes if needed, we suggest ReadWriteMany so we can scale the deployment later.
+  - ReadWriteOnce # Change this to your accessModes if needed, we suggest ReadWriteOnce so we can scale the deployment later.
   resources:
     requests:
       storage: 1Gi
@@ -35,10 +35,10 @@ metadata:
     app.kubernetes.io/managed-by: sredevopsorg
 
 spec:
-  storageClassName: longhorn-rwx # Change this to your storageClassName
+  storageClassName: local-path # Change this to your storageClassName
   volumeMode: Filesystem
   accessModes:
-  - ReadWriteMany # Change this to ReadWriteOnce if your storageClassName does not support ReadWriteMany
+  - ReadWriteOnce # Change this to ReadWriteOnce if your storageClassName does not support ReadWriteOnce
   resources:
     requests:
       storage: 1Gi

--- a/deploy/04-config.development.yaml
+++ b/deploy/04-config.development.yaml
@@ -27,13 +27,13 @@ stringData:
       "database": {
         "client": "sqlite3",
         "connection": {
-          "filename": "/home/node/app/ghost/content/data/ghost-dev.db"
+          "filename": "/home/nonroot/app/ghost/content/data/ghost-dev.db"
         }
       },
       "debug": true,
       "process": "local",
       "paths": {
-        "contentPath": "/home/node/app/ghost/content"
+        "contentPath": "/home/nonroot/app/ghost/content"
       },
       "privacy": {
         "useUpdateCheck": false,

--- a/deploy/04-config.development.yaml
+++ b/deploy/04-config.development.yaml
@@ -27,13 +27,13 @@ stringData:
       "database": {
         "client": "sqlite3",
         "connection": {
-          "filename": "/var/lib/ghost/content/data/ghost-dev.db"
+          "filename": "/home/node/app/ghost/content/data/ghost-dev.db"
         }
       },
       "debug": true,
       "process": "local",
       "paths": {
-        "contentPath": "/var/lib/ghost/content"
+        "contentPath": "/home/node/app/ghost/content"
       },
       "privacy": {
         "useUpdateCheck": false,

--- a/deploy/04-config.production.yaml
+++ b/deploy/04-config.production.yaml
@@ -48,7 +48,7 @@ stringData:
       "debug": false,
       "process": "local",
       "paths": {
-        "contentPath": "/home/node/app/ghost/content"
+        "contentPath": "/home/nonroot/app/ghost/content"
       },
       "privacy": {
         "useUpdateCheck": false,

--- a/deploy/04-config.production.yaml
+++ b/deploy/04-config.production.yaml
@@ -48,7 +48,7 @@ stringData:
       "debug": false,
       "process": "local",
       "paths": {
-        "contentPath": "/var/lib/ghost/content"
+        "contentPath": "/home/node/app/ghost/content"
       },
       "privacy": {
         "useUpdateCheck": false,

--- a/deploy/06-ghost-deployment.yaml
+++ b/deploy/06-ghost-deployment.yaml
@@ -44,9 +44,9 @@ spec:
         env:
 
         - name: GHOST_INSTALL
-          value: /home/node/app/ghost
+          value: /home/nonroot/app/ghost
         - name: GHOST_CONTENT
-          value: /home/node/app/ghost/content
+          value: /home/nonroot/app/ghost/content
         - name: NODE_ENV
           value: production
         securityContext:
@@ -71,20 +71,20 @@ spec:
             for dir in $DIRS; do
               if [ ! -d $GHOST_CONTENT/$dir ]; then
                 echo "Creating $GHOST_CONTENT/$dir directory"
-                mkdir -pv $GHOST_CONTENT/$dir && chown -Rfv 1000:1000 $GHOST_CONTENT/$dir || echo "Error creating $GHOST_CONTENT/$dir directory"
+                mkdir -pv $GHOST_CONTENT/$dir && chown -Rfv 65532:65532 $GHOST_CONTENT/$dir || echo "Error creating $GHOST_CONTENT/$dir directory"
               fi
             done
 
             echo "Changing ownership of $GHOST_CONTENT/themes directory"
-            chown -Rfv 1000:1000 $GHOST_CONTENT/themes || echo "Error changing ownership of $GHOST_CONTENT themes directory"
+            chown -Rfv 65532:65532 $GHOST_CONTENT/themes || echo "Error changing ownership of $GHOST_CONTENT themes directory"
 
             echo "Changing ownership of $GHOST_CONTENT/public directory"
-            chown -Rfv 1000:1000 $GHOST_CONTENT/public || echo "Error changing ownership of $GHOST_CONTENT public directory"
+            chown -Rfv 65532:65532 $GHOST_CONTENT/public || echo "Error changing ownership of $GHOST_CONTENT public directory"
 
 
         volumeMounts:
         - name: k8s-ghost-content
-          mountPath: /home/node/app/ghost/content
+          mountPath: /home/nonroot/app/ghost/content
           readOnly: false
 
       containers:
@@ -142,11 +142,11 @@ spec:
 
         volumeMounts:
         - name: k8s-ghost-content
-          mountPath: /home/node/app/ghost/content
+          mountPath: /home/nonroot/app/ghost/content
           readOnly: false
         - name: ghost-config-prod
           readOnly: true
-          mountPath: /home/node/app/ghost/config.production.json
+          mountPath: /home/nonroot/app/ghost/config.production.json
           subPath: config.production.json
         - name: tmp # This is the temporary volume mount to allow loading themes
           mountPath: /tmp
@@ -155,7 +155,7 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 1000
+          runAsUser: 65532
 
 
       restartPolicy: Always

--- a/deploy/06-ghost-deployment.yaml
+++ b/deploy/06-ghost-deployment.yaml
@@ -44,9 +44,9 @@ spec:
         env:
 
         - name: GHOST_INSTALL
-          value: /var/lib/ghost
+          value: /home/node/app/ghost
         - name: GHOST_CONTENT
-          value: /var/lib/ghost/content
+          value: /home/node/app/ghost/content
         - name: NODE_ENV
           value: production
         securityContext:
@@ -84,7 +84,7 @@ spec:
 
         volumeMounts:
         - name: k8s-ghost-content
-          mountPath: /var/lib/ghost/content
+          mountPath: /home/node/app/ghost/content
           readOnly: false
 
       containers:
@@ -142,11 +142,11 @@ spec:
 
         volumeMounts:
         - name: k8s-ghost-content
-          mountPath: /var/lib/ghost/content
+          mountPath: /home/node/app/ghost/content
           readOnly: false
         - name: ghost-config-prod
           readOnly: true
-          mountPath: /var/lib/ghost/config.production.json
+          mountPath: /home/node/app/ghost/config.production.json
           subPath: config.production.json
         - name: tmp # This is the temporary volume mount to allow loading themes
           mountPath: /tmp

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -26,8 +26,11 @@ var copyRecursiveSync = function(src, dest) {
 };
 
 // Define sources and destinations for both themes named "casper" and "source".
-let sourcePath = "/home/nonroot/app/ghost/content.orig/themes/";
-let destinationPath = "/home/nonroot/app/ghost/content/themes";
+          // Get an environment variable that specifies the path for sourcePath + "/content/themes" 
+let sourcePath = process.env.GHOST_CONTENT_ORIGINAL + "/content/themes";
+console.log("Source path: ", sourcePath);
+let destinationPath = process.env.GHOST_CONTENT + "/content/themes/";s
+console.log("Destination path: ", destinationPath);
 
 // Wrap the function in a try/catch block to handle any errors.
 try {

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,36 +1,37 @@
 
-// Source: https://stackoverflow.com/a/22185855/9084561
-
-const fs = require("fs")
-const path = require("path")
+const fs = require("fs");
+const path = require("path");
 
 /**
- * Look ma, it's cp -R.
+ * Look ma, it's cp -R, but verbose.
  * @param {string} src  The path to the thing to copy.
  * @param {string} dest The path to the new copy.
  */
 var copyRecursiveSync = function(src, dest) {
+  console.log(`Starting to copy from ${src} to ${dest}`);
   var exists = fs.existsSync(src);
   var stats = exists && fs.statSync(src);
   var isDirectory = exists && stats.isDirectory();
   if (isDirectory) {
+    console.log(`Creating directory: ${dest}`);
     fs.mkdirSync(dest, { recursive: true });
     fs.readdirSync(src).forEach(function(childItemName) {
       copyRecursiveSync(path.join(src, childItemName),
                         path.join(dest, childItemName));
     });
   } else {
+    console.log(`Copying file from ${src} to ${dest}`);
     fs.copyFileSync(src, dest, fs.constants.COPYFILE_FICLONE);
   }
 };
 
 // Define sources and destinations for both themes named "casper" and "source".
-let sourcePath = ("/home/node/app/ghost/content.orig/themes/");
-let destinationPath = ("/home/node/app/ghost/content/themes");
+let sourcePath = "/home/nonroot/app/ghost/content.orig/themes/";
+let destinationPath = "/home/nonroot/app/ghost/content/themes";
 
 // Wrap the function in a try/catch block to handle any errors.
 try {
-  copyRecursiveSync(sourcePath, destinationPath)
+  copyRecursiveSync(sourcePath, destinationPath);
   console.log("Copy successful!");
 }
 catch (error) {

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -27,9 +27,9 @@ var copyRecursiveSync = function(src, dest) {
 
 // Define sources and destinations for both themes named "casper" and "source".
           // Get an environment variable that specifies the path for sourcePath + "/content/themes" 
-let sourcePath = process.env.GHOST_CONTENT_ORIGINAL + "/content/themes";
+let sourcePath = process.env.GHOST_CONTENT_ORIGINAL + "/themes";
 console.log("Source path: ", sourcePath);
-let destinationPath = process.env.GHOST_CONTENT + "/content/themes/";s
+let destinationPath = process.env.GHOST_CONTENT + "/themes/";
 console.log("Destination path: ", destinationPath);
 
 // Wrap the function in a try/catch block to handle any errors.

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -25,8 +25,8 @@ var copyRecursiveSync = function(src, dest) {
 };
 
 // Define sources and destinations for both themes named "casper" and "source".
-let sourcePath = ("/var/lib/ghost/content.orig/themes/");
-let destinationPath = ("/var/lib/ghost/content/themes");
+let sourcePath = ("/home/node/app/ghost/content.orig/themes/");
+let destinationPath = ("/home/node/app/ghost/content/themes");
 
 // Wrap the function in a try/catch block to handle any errors.
 try {

--- a/examples/config.development.sample.yaml
+++ b/examples/config.development.sample.yaml
@@ -27,13 +27,13 @@ stringData:
       "database": {
         "client": "sqlite3",
         "connection": {
-          "filename": "/home/node/app/ghost/content/data/ghost-dev.db"
+          "filename": "/home/nonroot/app/ghost/content/data/ghost-dev.db"
         }
       },
       "debug": true,
       "process": "local",
       "paths": {
-        "contentPath": "/home/node/app/ghost/content"
+        "contentPath": "/home/nonroot/app/ghost/content"
       },
       "privacy": {
         "useUpdateCheck": false,

--- a/examples/config.development.sample.yaml
+++ b/examples/config.development.sample.yaml
@@ -27,13 +27,13 @@ stringData:
       "database": {
         "client": "sqlite3",
         "connection": {
-          "filename": "/var/lib/ghost/content/data/ghost-dev.db"
+          "filename": "/home/node/app/ghost/content/data/ghost-dev.db"
         }
       },
       "debug": true,
       "process": "local",
       "paths": {
-        "contentPath": "/var/lib/ghost/content"
+        "contentPath": "/home/node/app/ghost/content"
       },
       "privacy": {
         "useUpdateCheck": false,

--- a/examples/config.production.sample.yaml
+++ b/examples/config.production.sample.yaml
@@ -48,7 +48,7 @@ stringData:
       "debug": true,
       "process": "local",
       "paths": {
-        "contentPath": "/var/lib/ghost/content"
+        "contentPath": "/home/node/app/ghost/content"
       }
     }
     

--- a/examples/config.production.sample.yaml
+++ b/examples/config.production.sample.yaml
@@ -48,7 +48,7 @@ stringData:
       "debug": true,
       "process": "local",
       "paths": {
-        "contentPath": "/home/node/app/ghost/content"
+        "contentPath": "/home/nonroot/app/ghost/content"
       }
     }
     


### PR DESCRIPTION
Chore: Update Dockerfile and deployment files
This commit updates the Dockerfile and various deployment files to use the new installation and content paths for Ghost. The installation directory is changed to "/home/nonroot/app/ghost" and the content directory is changed to "/home/nonroot/app/ghost/content". This ensures that the correct paths are used for the Ghost installation and content storage. The changes are necessary to align with recent updates in the repository and to maintain consistency in the file structure.