### PR TITLE
Provide access to all directories

### DIFF
--- a/deploy/06-ghost-deployment.yaml
+++ b/deploy/06-ghost-deployment.yaml
@@ -80,18 +80,10 @@ spec:
             for dir in $DIRS; do
               if [ ! -d $GHOST_CONTENT/$dir ]; then
                 echo "Creating $GHOST_CONTENT/$dir directory"
-                mkdir -pv $GHOST_CONTENT/$dir && chown -Rfv 65532:65532 $GHOST_CONTENT/$dir || echo "Error creating $GHOST_CONTENT/$dir directory"
+                mkdir -pv $GHOST_CONTENT/$dir || echo "Error creating $GHOST_CONTENT/$dir directory"
               fi
+              chown -Rfv 65532:65532 $GHOST_CONTENT/$dir && echo "chown ok on $dir" || echo "Error changing ownership of $GHOST_CONTENT/$dir directory"
             done
-            
-            echo "Changing ownership of $GHOST_CONTENT/data directory"
-            chown -Rf 65532:65532 $GHOST_CONTENT/data && echo "chown ok on data" || echo "Error changing ownership of $GHOST_CONTENT/data directory"
-
-            echo "Changing ownership of $GHOST_CONTENT/themes directory"
-            chown -Rf 65532:65532 $GHOST_CONTENT/themes && echo "chown ok on themes" || echo "Error changing ownership of $GHOST_CONTENT/themes directory"
-
-            echo "Changing ownership of $GHOST_CONTENT/public directory"
-            chown -Rf 65532:65532 $GHOST_CONTENT/public && echo "chown ok in public" || echo "Error changing ownership of $GHOST_CONTENT public directory"
             exit 0
 
 

--- a/deploy/06-ghost-deployment.yaml
+++ b/deploy/06-ghost-deployment.yaml
@@ -83,6 +83,9 @@ spec:
                 mkdir -pv $GHOST_CONTENT/$dir && chown -Rfv 65532:65532 $GHOST_CONTENT/$dir || echo "Error creating $GHOST_CONTENT/$dir directory"
               fi
             done
+            
+            echo "Changing ownership of $GHOST_CONTENT/data directory"
+            chown -Rf 65532:65532 $GHOST_CONTENT/data && echo "chown ok on data" || echo "Error changing ownership of $GHOST_CONTENT/data directory"
 
             echo "Changing ownership of $GHOST_CONTENT/themes directory"
             chown -Rf 65532:65532 $GHOST_CONTENT/themes && echo "chown ok on themes" || echo "Error changing ownership of $GHOST_CONTENT/themes directory"


### PR DESCRIPTION
# Overview

Hi, I follow your project for running ghost on my Raspberry Pi's and enjoy using it. I had been running your container and your example for awhile and recently decided to update recently. I noticed you had updated some of the logic and didn't think much of it. However, when the update was actually taking place, it failed because the logic for permission you include as an example had changed. 

Basically I was getting an error similar to the one below

```
[2024-10-25 00:58:02] ERROR "POST /ghost/api/admin/images/upload/" 500 59ms

An unexpected error occurred, please try again.

"EACCES: permission denied, copyfile '/tmp/4da1783d52246c50271c4d5cad81019a_processed' -> '/home/nonroot/app/ghost/content/images/2024/10/setup.png'"

Error ID:
    2f67f4c0-926c-11ef-ab6b-bf094aa15ae2

Error Code:
    UNEXPECTED_ERROR

----------------------------------------

Error: EACCES: permission denied, copyfile '/tmp/4da1783d52246c50271c4d5cad81019a_processed' -> '/home/nonroot/app/ghost/content/images/2024/10/setup.png'
    at prepareError (/home/nonroot/app/ghost/versions/5.95.0/node_modules/@tryghost/mw-error-handler/lib/mw-error-handler.js:113:19)
```

I think this only affects existing deployments. New deployments wouldn't run into this issue. I've update your example to just give the user access to all of the folders it needs because otherwise, my (and I'm expecting others) deployments will fail.

Hope this helps :) 