### PR TITLE
Update Ghost on Kubernetes to version 6.0

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,153 +1,155 @@
-# Ghost en Kubernetes por SREDevOps.Org
+# **Ghost en Kubernetes (v6.x) por SREDevOps.Org**
 
-[![SREDevOps.org](https://github.com/sredevopsorg/.github/assets/34670018/6878e00f-635c-4553-8df7-3b20406fdb4f)](https://www.sredevops.org)
+Despliega la principal plataforma de publicación de código abierto, **Ghost**, en Kubernetes con la máxima **seguridad** y **eficiencia** utilizando una imagen de contenedor endurecida y multi-arquitectura.
 
-_**SREDevOps.org**: SRE, DevOps, Linux, Ethical Hacking, AI, ML, Open Source, Cloud Native, Platform Engineering en Español, Portugués (Brasil) y English_
+Mantenido por ***[SREDevOps.org](https://www.sredevops.org)**: SRE, DevOps, Linux, Hacking Ético, IA, ML, Código Abierto, Cloud Native, Platform Engineering en Inglés, Español y Portugués (Brasil).*
 
 [![Build Multiarch](https://github.com/sredevopsorg/ghost-on-kubernetes/actions/workflows/multi-build.yaml/badge.svg?branch=main)](https://github.com/sredevopsorg/ghost-on-kubernetes/actions/workflows/multi-build.yaml) [![Image Size](https://ghcr-badge.egpl.dev/sredevopsorg/ghost-on-kubernetes/size?color=%2344cc11&tag=main&label=main+image+size)](https://github.com/sredevopsorg/ghost-on-kubernetes/pkgs/container/ghost-on-kubernetes) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sredevopsorg/ghost-on-kubernetes/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sredevopsorg/ghost-on-kubernetes) [![Fork this repository](https://img.shields.io/github/forks/sredevopsorg/ghost-on-kubernetes?style=social)](https://github.com/sredevopsorg/ghost-on-kubernetes/fork) [![Star this repository](https://img.shields.io/github/stars/sredevopsorg/ghost-on-kubernetes?style=social)](https://github.com/sredevopsorg/ghost-on-kubernetes/stargazers) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8888/badge)](https://www.bestpractices.dev/projects/8888) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/ghost-on-kubernetes)](https://artifacthub.io/packages/search?repo=ghost-on-kubernetes)
 
-## Introducción
+## **Aspectos Destacados: Seguridad y Eficiencia**
 
-Este repositorio implementa **Ghost CMS v6.xx.x** desde [@TryGhost (Oficial)](https://github.com/TryGhost/Ghost) en **Kubernetes**, usando nuestra imagen personalizada con mejoras significativas diseñadas para su uso en Kubernetes [(Dockerfile)](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile). Revisa todo este README para más información.
+Este repositorio implementa Ghost CMS v6.xx.x de [@TryGhost (Oficial)](https://github.com/TryGhost/Ghost) en Kubernetes con una imagen personalizada, que ofrece mejoras significativas para el uso en producción y características de seguridad en Kubernetes.
 
-## Características
+### **Seguridad Mejorada**
 
-- Tanto **Ghost** como **MySQL** se ejecutan como usuarios *non-root* en Kubernetes, mejorando considerablemente la seguridad, junto con otras mejoras en la imagen personalizada.
-- Soporte **multi-arch** (amd64 y arm64).
-- Se usa la imagen oficial **Node 22 Jod LTS** como entorno de build. [Dockerfile](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile#L5).
-- Implementa un **multi-stage build**, reduciendo el tamaño final de la imagen y mejorando la seguridad al eliminar componentes innecesarios.
-- Usa **[Distroless Node 22 Debian 12](https://github.com/GoogleContainerTools/distroless/blob/main/README.md)** como entorno de runtime en la imagen final.
-- La imagen oficial de Ghost usaba *gosu*, pero fue removido en favor de una ejecución nativa sin privilegios dentro del contenedor. Todo corre como usuario *non-root* (UID/GID 65532) en el contenedor **Distroless**. Este cambio reduce 6 vulnerabilidades críticas y 34 altas reportadas por Docker Scout en la imagen oficial de Ghost.
+* **Ejecución Sin Root:** Tanto los componentes de Ghost como los de MySQL se ejecutan exclusivamente como un **usuario sin privilegios (non-root)** (UID/GID 65532) en Kubernetes, previniendo posibles ataques de escalada de privilegios.
+* **Tiempo de Ejecución Distroless:** Utilizamos **Google Container Tools Distroless Debian 13 - NodeJS 22** como el entorno de tiempo de ejecución final. Las imágenes **Distroless** contienen solo las dependencias de la aplicación y el lenguaje requeridas, **excluyendo shells y gestores de paquetes**, lo que las hace sustancialmente más seguras y reduce la superficie de ataque.
+* **Reducción de Vulnerabilidades:** Al reemplazar `gosu` con un flujo de ejecución de contenedor nativo y adoptar Distroless, eliminamos varias vulnerabilidades críticas reportadas en la imagen original de Ghost:
+  * **Resultado:** Solo este cambio redujo **6 vulnerabilidades críticas** y **34 vulnerabilidades altas** reportadas por Docker Scout en la imagen oficial.
 
-  - Ejemplo de escaneo para la [Imagen Oficial de Ghost](https://hub.docker.com/_/ghost/tags)
+**Ejemplo de Reportes de Seguridad:**
 
-    ![Docker Scout Report - Ghost Official Image](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ghost.png)
+| Imagen Oficial de Ghost | Imagen de Ghost en Kubernetes |
+| :---- | :---- |
+| Escaneo de ejemplo para la [Imagen Oficial de Ghost](https://hub.docker.com/_/ghost/tags): ![Reporte de Docker Scout - Imagen Oficial de Ghost](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ghost.png) | Ejemplo de nuestra [Imagen de Ghost en Kubernetes en Docker Hub](https://hub.docker.com/r/ngeorger/ghost-on-kubernetes/tags): ![Reporte de Docker Scout - Imagen de Ghost en Kubernetes](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ngeorger.png) |
 
-  - Ejemplo de nuestra [Imagen Ghost on Kubernetes en Docker Hub](https://hub.docker.com/r/ngeorger/ghost-on-kubernetes/tags)
+### **Rendimiento y Arquitectura**
 
-    ![Docker Scout Report - Ghost on Kubernetes Image](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ngeorger.png)
+* **Artefactos de Build Personalizados:** Mantenemos dos Dockerfiles distintos para producción y desarrollo:
+  * **Imagen de Producción:** La imagen principal construida utilizando nuestro proceso de construcción endurecido y multi-etapa. Ver el [Dockerfile](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile).
+  * **Imagen de Desarrollo:** Una variante adaptada para pruebas, que incluye soporte para SQLite. Ver el [Dockerfile-dev](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile-dev).
+* **Soporte Multi-Arquitectura:** Las imágenes están construidas para las arquitecturas **amd64** y **arm64**.
+* **Build Multi-Etapa:** Utilizamos la imagen oficial de Node 22 Jod LTS para la construcción, lo que reduce significativamente el tamaño final de la imagen y mejora la seguridad al eliminar componentes de construcción innecesarios.
+* **Ghost v6 y NodeJS 22 LTS Actualizados:** Utilizando las últimas versiones estables para seguridad y rendimiento.
+* **Punto de Entrada Robusto (entrypoint.js):** Un script de punto de entrada **Node.js** personalizado, ejecutado por el usuario sin privilegios, maneja las operaciones de tiempo de ejecución necesarias, como la actualización de temas predeterminados, antes de iniciar la aplicación Ghost. El script se puede revisar aquí: [entrypoint.js](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/entrypoint.js).
+* **Contenedor Init Dedicado:** El despliegue incluye un **initContainer** para manejar la creación de directorios, la propiedad correcta (UID/GID 65532) y la configuración de permisos antes del lanzamiento del contenedor principal de Ghost, asegurando una operación fluida dentro del contenedor Distroless.
 
-- Nuevo **Entrypoint** basado en script **Node.js** ejecutado por el usuario sin privilegios dentro del contenedor **Distroless**, que actualiza los temas por defecto y lanza la aplicación Ghost.
-- Se usa siempre la última versión de Ghost 6 al momento del build.
+## **Resumen de la Arquitectura de Despliegue**
 
-## Cambios recientes
+Este proyecto proporciona archivos manifest completos de Kubernetes (`deploy/`) para ejecutar una instancia de Ghost lista para producción, respaldada por una base de datos **MySQL**.
 
-Actualizaciones clave para mejorar la seguridad y eficiencia de Ghost en Kubernetes:
+| Recurso | Componentes | Detalles |
+| :---- | :---- | :---- |
+| **Namespace** | ghost-on-kubernetes | Proporciona aislamiento lógico para todos los componentes. (Archivo: [00-namespace.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/00-namespace.yaml)) |
+| **StatefulSet** | ghost-on-kubernetes-mysql | Gestiona la base de datos MySQL 8, asegurando red estable y almacenamiento persistente. (Archivo: [05-mysql.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/05-mysql.yaml)) |
+| **Deployment** | ghost-on-kubernetes | Gestiona los pods de la aplicación Ghost v6. (Archivo: [06-ghost-deployment.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/06-ghost-deployment.yaml)) |
+| **Services** | ghost-on-kubernetes-service, ghost-on-kubernetes-mysql-service | Expone Ghost (2368) y MySQL (3306) internamente dentro del clúster. (Archivo: [03-service.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/03-service.yaml)) |
+| **PersistentVolumeClaims (PVC)** | k8s-ghost-content, ghost-on-kubernetes-mysql-pvc | Solicita almacenamiento persistente para el contenido de Ghost (temas, imágenes) y los datos de MySQL. (Archivo: [02-pvc.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/02-pvc.yaml)) |
+| **Secrets** | ghost-config-prod, ghost-on-kubernetes-mysql-env, tls-secret | Almacena de forma segura la configuración de Ghost, las credenciales de la base de datos y los certificados TLS (opcional). (Archivos: [01-mysql-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-mysql-config.yaml), [04-ghost-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/04-ghost-config.yaml), [01-tls.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-tls.yaml)) |
+| **Ingress** | ghost-on-kubernetes-ingress | Expone la aplicación Ghost al mundo exterior a través de HTTP/HTTPS (requiere un TLD). (Archivo: [07-ingress.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/07-ingress.yaml)) |
 
-- **Ghost v6 actualizado**: Usamos la nueva versión, revisa la [documentación oficial](https://docs.ghost.org/update).
-- **NodeJS actualizado**: Desde Iron LTS (Node v20) a Jod LTS (Node v22).
-- **Soporte multi-arch**: Imágenes para amd64 y arm64.
-- **Imagen Distroless**: Basada en [@GoogleContainerTools](https://github.com/GoogleContainerTools), solo con los componentes necesarios para ejecutar la app.
-- **MySQL StatefulSet**: Ahora MySQL se ejecuta como StatefulSet, lo que permite almacenamiento persistente y redes estables.
-- **Init Container**: Nuevo init container que prepara configuraciones, permisos y directorios antes de iniciar Ghost. Ver [deploy/06-ghost-deployment.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/06-ghost-deployment.yaml).
-- **Entrypoint Script**: Script NodeJS que corre como usuario *non-root* dentro del contenedor Distroless para actualizar temas y lanzar Ghost. [entrypoint.js](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/entrypoint.js)
+*Nota*: Puedes alojar múltiples instancias de Ghost reemplazando la especificación de Namespace en cada archivo manifest.
 
-## Instrucciones de instalación
+## **Instrucciones de Instalación (Producción)**
 
-### 0. Clonar el repositorio
+Sigue estos pasos para desplegar Ghost en tu clúster de Kubernetes.
+
+### **Prerrequisitos**
+
+1. Un clúster de Kubernetes en funcionamiento (`kubectl` configurado).
+2. Un StorageClass provisionado (requerido para los PVCs).
+
+### **0. Clonar (o hacer fork) del Repositorio**
 
 ```bash
+## Clonar el repositorio
 git clone https://github.com/sredevopsorg/ghost-on-kubernetes.git --depth 1 --branch main --single-branch --no-tags
+## Cambiar de directorio
 cd ghost-on-kubernetes
-git checkout -b my-branch --no-track --detach
 ```
 
-### 1. Revisar configuraciones de ejemplo
+### **1. Revisar y Configurar**
 
-Los archivos de ejemplo están en [examples](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/examples/):
+Revisa los archivos de configuración de ejemplo y modifica los manifests en la carpeta `deploy/` para adaptarlos a tu entorno (ej. clase de almacenamiento, nombre de dominio, valores de secretos).
 
-- `config.development.sample.yaml`: Configuración para desarrollo, usa SQLite.
-- `config.production.sample.yaml`: Configuración para producción, usa MySQL 8. Requiere dominio válido y [Ingress configurado](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/07-ingress.yaml).
+* **Configuraciones:** Revisa los archivos de configuración de ejemplo en el directorio [examples/](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/examples/):
+  * `config.production.sample.yaml`: Configuración recomendada usando MySQL 8. Requiere un **dominio de nivel superior (TLD)** válido para el campo `url` y la configuración de Ingress.
+  * `config.development.sample.yaml`: Utiliza SQLite para entornos de prueba.
+* **Documentación Oficial de Ghost:** Consulta la [documentación oficial de Ghost](https://ghost.org/docs/config/#custom-configuration-files) para opciones de configuración detalladas.
 
-Más detalles en la [documentación oficial de Ghost](https://ghost.org/docs/config/#custom-configuration-files).
+### **2. Secuencia de Despliegue**
 
-### 2. Editar valores según tus necesidades
+Es **crucial** aplicar los manifests en el orden correcto para asegurar la resolución de dependencias (especialmente los componentes de la base de datos).
 
-Revisa cada manifiesto dentro de [deploy/](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/).
+1. **Crear el Namespace:**
 
-### Arquitectura de despliegue Ghost en Kubernetes
+    `kubectl apply -f deploy/00-namespace.yaml`
 
-Ghost requiere varios recursos Kubernetes:
+2. **Crear Secrets (Credenciales y Configuración):**
 
-#### Namespace
+    ```bash
+    # IMPORTANTE: Personaliza estos secretos antes de aplicarlos
+    kubectl apply -f deploy/01-mysql-config.yaml
+    kubectl apply -f deploy/04-ghost-config.yaml
+    kubectl apply -f deploy/01-tls.yaml
+    ```
 
-Aisla recursos en `ghost-on-kubernetes`.
+3. **Crear Almacenamiento Persistente y Services:**
 
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ghost-on-kubernetes
-```
+    ```bash
+    kubectl apply -f deploy/02-pvc.yaml
+    kubectl apply -f deploy/03-service.yaml
+    ```
 
-#### Secrets
+4. **Desplegar la Base de Datos MySQL (StatefulSet):**
 
-Guarda datos sensibles como contraseñas y certificados TLS.
+    ```bash
+    # Espera a que el PVC de MySQL esté enlazado
+    kubectl apply -f deploy/05-mysql.yaml
+    ```
 
-- `ghost-config-prod`
-- `ghost-on-kubernetes-mysql-env`
-- `tls-secret`
+5. **Desplegar la Aplicación Ghost (Deployment):**
 
-#### PersistentVolumeClaims
+    ```bash
+    # Espera a que MySQL esté listo antes de comenzar
+    kubectl apply -f deploy/06-ghost-deployment.yaml
+    ```
 
-Permite almacenamiento persistente para contenido Ghost y base de datos MySQL.
+6. **Exponer Ghost con Ingress (Opcional/Recomendado):**
 
-#### Services
+    ```bash
+    # Enruta el tráfico externo al Service de Ghost
+    kubectl apply -f deploy/07-ingress.yaml
+    ```
 
-Expone Ghost y MySQL dentro del clúster.
+## **¡Tu Blog Ghost está Desplegado\!**
 
-#### StatefulSet
+¡Felicidades\! Has desplegado una instancia de Ghost v6 altamente segura y escalable en Kubernetes.
 
-Administra la base de datos MySQL con almacenamiento persistente.
+### **Acceso Sin Nombre de Dominio (Pruebas)**
 
-#### Deployment
+Para previsualizar el sitio web sin configurar Ingress o un TLD, puedes usar el *port forwarding*:
 
-Gestiona la aplicación Ghost (stateless).
+1. Configura temporalmente las URL `url` y `admin` en tu Secret `config.production.json` para usar `http://localhost:2368/`.
+2. Reinicia el/los pod(s) de Ghost después de actualizar el Secret.
+3. Ejecuta el comando de *port-forwarding*:
 
-#### Ingress
-
-Expone Ghost a Internet mediante dominio.
-
-## Despliegue en Kubernetes
-
-Aplica los archivos **en orden**:
-
-```bash
-kubectl apply -f deploy/00-namespace.yaml
-kubectl apply -f deploy/01-mysql-config.yaml
-kubectl apply -f deploy/04-ghost-config.yaml
-kubectl apply -f deploy/01-tls.yaml
-kubectl apply -f deploy/02-pvc.yaml
-kubectl apply -f deploy/03-service.yaml
-kubectl apply -f deploy/05-mysql.yaml
-kubectl apply -f deploy/06-ghost-deployment.yaml
-kubectl apply -f deploy/07-ingress.yaml
-```
-
-## Tu blog Ghost está desplegado
-
-Has desplegado Ghost en Kubernetes exitosamente. Personaliza configuraciones según tus necesidades (almacenamiento, recursos, dominio, etc.).
-
-## Acceder sin dominio
-
-Para previsualizar Ghost sin dominio:
-
-Configura `url` y `admin url` como `http://localhost:2368/`, reinicia el pod y usa port-forward:
+<!-- end list -->
 
 ```bash
 kubectl port-forward -n ghost-on-kubernetes services ghost-on-kubernetes-service 2368:2368
 ```
 
-## Contribuir
+## Contribuciones
 
-Contribuciones son bienvenidas. Revisa [CONTRIBUTING.md](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/CONTRIBUTING.md).
+¡Damos la bienvenida a las contribuciones de la comunidad\! Por favor, revisa el archivo [CONTRIBUTING.md](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/CONTRIBUTING.md) para obtener más información sobre cómo contribuir a este proyecto.
 
-## Licencia y créditos
+## Licencia y Créditos
 
-- Proyecto bajo **MIT License**. Ver [LICENSE](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/LICENSE).
-- **Ghost CMS** está bajo [MIT License](https://github.com/TryGhost/Ghost/blob/main/LICENSE).
-- Las imágenes base (Node y Distroless) pertenecen a sus respectivos autores.
+* Este proyecto está licenciado bajo la **Licencia MIT**. Por favor, revisa el archivo [LICENSE](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/LICENSE) para obtener más información.
+* Ghost CMS está licenciado bajo la [Licencia MIT](https://github.com/TryGhost/Ghost/blob/main/LICENSE).
+* La imagen de node y la imagen Distroless están licenciadas por sus respectivos propietarios.
 
-## Historial de estrellas
+## Historial de Estrellas
 
 ![Star History Chart](https://api.star-history.com/svg?repos=sredevopsorg/ghost-on-kubernetes&type=Date&theme=dark)

--- a/README.md
+++ b/README.md
@@ -1,278 +1,140 @@
-# Ghost on Kubernetes by SREDevOps.Org
+# **Ghost on Kubernetes (v6.x) by SREDevOps.Org**
 
-[![SREDevOps.org](https://github.com/sredevopsorg/.github/assets/34670018/6878e00f-635c-4553-8df7-3b20406fdb4f)](https://www.sredevops.org)
+Deploy the leading open-source publishing platform, Ghost, on Kubernetes with maximum **security** and **efficiency** using a hardened, multi-arch container image.
 
-_**SREDevOps.org**: SRE, DevOps, Linux, Ethical Hacking, AI, ML, Open Source, Cloud Native, Platform Engineering en Español, Portugués (Brasil) and English_
+Maintained by ***[SREDevOps.org](https://www.sredevops.org)**: SRE, DevOps, Linux, Ethical Hacking, AI, ML, Open Source, Cloud Native, Platform Engineering in English, Español, and Portugués (Brasil).*
 
 [![Build Multiarch](https://github.com/sredevopsorg/ghost-on-kubernetes/actions/workflows/multi-build.yaml/badge.svg?branch=main)](https://github.com/sredevopsorg/ghost-on-kubernetes/actions/workflows/multi-build.yaml) [![Image Size](https://ghcr-badge.egpl.dev/sredevopsorg/ghost-on-kubernetes/size?color=%2344cc11&tag=main&label=main+image+size)](https://github.com/sredevopsorg/ghost-on-kubernetes/pkgs/container/ghost-on-kubernetes) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sredevopsorg/ghost-on-kubernetes/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sredevopsorg/ghost-on-kubernetes) [![Fork this repository](https://img.shields.io/github/forks/sredevopsorg/ghost-on-kubernetes?style=social)](https://github.com/sredevopsorg/ghost-on-kubernetes/fork) [![Star this repository](https://img.shields.io/github/stars/sredevopsorg/ghost-on-kubernetes?style=social)](https://github.com/sredevopsorg/ghost-on-kubernetes/stargazers) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8888/badge)](https://www.bestpractices.dev/projects/8888) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/ghost-on-kubernetes)](https://artifacthub.io/packages/search?repo=ghost-on-kubernetes)
 
-## Introduction
+## **Key Highlights: Security & Efficiency**
 
-This repository implements Ghost CMS v6.xx.x from [@TryGhost (Official)](https://github.com/TryGhost/Ghost) on Kubernetes, with our custom image, which has significant improvements intended to be used on Kubernetes [(Dockerfile)](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile). See this whole README for more information.
+This repository implements Ghost CMS v6.xx.x from [@TryGhost (Official)](https://github.com/TryGhost/Ghost) on Kubernetes with a custom built image, which delivers significant improvements for production use and security features in Kubernetes.
 
-## Features
+### **Enhanced Security**
 
-- Both Ghost and MySQL components run as non-root user in Kubernetes, which significantly improves security, in addition to our custom image enhancements.
-- Multi-arch support (amd64 and arm64) and also a dev variant with sqlite support.
-- We use the official Node 22 Jod LTS image as our build environment. [Dockerfile](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile#L5).
-- We introduce a multi-stage build, which reduces the final image size and improves security by removing unnecessary components from the final image.
-- [Distroless Node 22 Debian 13](https://github.com/GoogleContainerTools/distroless/blob/main/README.md) as our runtime environment for the final image stage.
-- The official Ghost image used gosu, but we removed it in favor of a clean and native container based executions. Now everything runs as non-root (UID/GID 65532) inside the Distroless container. This change alone reduces 6 critical vulnerabilities and 34 high vulnerabilities reported by Docker Scout in the original Ghost image. References:
+* **Non-Root Execution:** Both the Ghost and MySQL components run exclusively as a non-root user (UID/GID 65532) in Kubernetes, preventing potential privilege escalation attacks.  
+* **Distroless Runtime:** We utilize **Google Container Tools Distroless Debian 13 - NodeJS 22** as the final runtime environment. Distroless images contain only the required application and language dependencies, **excluding shells and package managers**, making them substantially more secure and reducing the attack surface.  
+* **Vulnerability Reduction:** By replacing gosu with a native container execution flow and adopting Distroless, we removed several critical vulnerabilities reported in the original Ghost image:  
+  * **Result:** This change alone reduced **6 critical vulnerabilities** and **34 high vulnerabilities** reported by Docker Scout in the official image.
 
-  - Example scan for the [Ghost Official Image](https://hub.docker.com/_/ghost/tags)
+**Example Security Reports:**
 
-    ![Docker Scout Report - Ghost Official Image](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ghost.png)
+| Ghost Official Image | Ghost on Kubernetes Image |
+| :---- | :---- |
+| Example scan for the [Ghost Official Image](https://hub.docker.com/_/ghost/tags): ![Docker Scout Report - Ghost Official Image](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ghost.png) | Example of our [Ghost on Kubernetes Image on Docker Hub](https://hub.docker.com/r/ngeorger/ghost-on-kubernetes/tags): ![Docker Scout Report - Ghost on Kubernetes Image](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ngeorger.png) |
 
-  - Example of our [Ghost on Kubernetes Image on Docker Hub](https://hub.docker.com/r/ngeorger/ghost-on-kubernetes/tags)
+### **Performance & Architecture**
 
-    ![Docker Scout Report - Ghost on Kubernetes Image](https://raw.githubusercontent.com/sredevopsorg/ghost-on-kubernetes/main/docs/images/dockerhub-ngeorger.png)
+* **Custom Build Artifacts:** We maintain two distinct Dockerfiles for production and development:  
+  * **Production Image:** The main image built using our hardened, multi-stage build process. See the [Dockerfile](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile).  
+  * **Development Image:** A variant tailored for testing, which bundles SQLite support. See the [Dockerfile-dev](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile-dev).  
+* **Multi-Arch Support:** Images are built for both amd64 and arm64 architectures.  
+* **Multi-Stage Build:** We use the official Node 22 Jod LTS image for building, which significantly reduces the final image size and improves security by removing unnecessary build components.  
+* **Updated Ghost v6 & NodeJS 22 LTS:** Using the latest stable versions for security and performance.  
+* **Robust Entrypoint (entrypoint.js):** A custom Node.js entrypoint script, executed by the unprivileged user, handles necessary runtime operations like updating default themes before starting the Ghost application. The script can be reviewed here: [entrypoint.js](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/entrypoint.js).  
+* **Dedicated Init Container:** The deployment includes an initContainer to handle directory creation, correct ownership (UID/GID 65532), and permission setting prior to the main Ghost container launch, ensuring seamless operation inside the Distroless container.
 
-- New Entrypoint flow, using a Node.js script executed by the unprivileged Node user inside the Distroless container, which updates the default themes and starts the Ghost application, an operation that is performed inside the Distroless container itself.
-- We use the latest version of Ghost 6 (when the image is built).
+## **Deployment Architecture Overview**
 
-## Recent updates and changes
+This project provides complete Kubernetes manifest files (deploy/) to run a production-ready Ghost instance backed by a MySQL database.
 
-We've made some significant updates to improve the security and efficiency of our Ghost implementation on Kubernetes:
+| Resource | Components | Details |
+| :---- | :---- | :---- |
+| **Namespace** | ghost-on-kubernetes | Provides logical isolation for all components. (File: [00-namespace.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/00-namespace.yaml)) |
+| **StatefulSet** | ghost-on-kubernetes-mysql | Manages the MySQL 8 database, ensuring stable networking and persistent storage. (File: [05-mysql.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/05-mysql.yaml)) |
+| **Deployment** | ghost-on-kubernetes | Manages the Ghost v6 application pods. (File: [06-ghost-deployment.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/06-ghost-deployment.yaml)) |
+| **Services** | ghost-on-kubernetes-service, ghost-on-kubernetes-mysql-service | Exposes Ghost (2368) and MySQL (3306) internally within the cluster. (File: [03-service.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/03-service.yaml)) |
+| **PersistentVolumeClaims (PVC)** | k8s-ghost-content, ghost-on-kubernetes-mysql-pvc | Requests persistent storage for Ghost content (themes, images) and MySQL data. (File: [02-pvc.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/02-pvc.yaml)) |
+| **Secrets** | ghost-config-prod, ghost-on-kubernetes-mysql-env, tls-secret | Securely stores Ghost configuration, database credentials, and TLS certificates (optional). (Files: [01-mysql-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-mysql-config.yaml), [04-ghost-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/04-ghost-config.yaml), [01-tls.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-tls.yaml)) |
+| **Ingress** | ghost-on-kubernetes-ingress | Exposes the Ghost application to the outside world via HTTP/HTTPS (requires a TLD). (File: [07-ingress.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/07-ingress.yaml)) |
 
-- **Updated Ghost v6**: We are using the new Ghost v6, please check the [Official Docs](https://docs.ghost.org/update) for more details. 
-- **Updated NodeJS version**: From Iron LTS (Node v20) into Jod LTS (Node v22)
-- **Multi-arch support**: The images are now multi-arch, with support for amd64 and arm64.
-- **Distroless Image**: We use [@GoogleContainerTools](https://github.com/GoogleContainerTools)'s [Distroless Debian 13 - NodeJS 22](https://github.com/ogleContainerTools/distroless/blob/main/examples/nodejs/Dockerfile) as the execution environment for the final image. Distroless images are minimal images that contain only the required components of the base image and the specific language to run the application, without shells, package managers, making them more secure and efficient than traditional images, even lighter than "slim" variants.
-- **Dev image variant with sqlite support**: We added a [Dockerfile-dev](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile-dev), with bundled sqlite3 dependencies and node environment configured as "development". 
-- **MySQL StatefulSet**: We've changed the MySQL implementation to a StatefulSet. This provides stable network identifiers and rsistent storage, which is important for databases like MySQL that need to maintain state.
-- **Init Container**: We've added an init container to the Ghost deployment. This container is responsible for setting up the necessary nfiguration files and directories before the main Ghost container starts, ensuring the right directories are created, correct ownership r user node inside distroless container UID/GID to 65532, and the correct permissions are set.  Check [deploy/06-ghost-deployment.yaml]ttps://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/06-ghost-deployment.yaml) for details on these changes.
-- **Entrypoint Script**: We've introduced a new entrypoint script that runs as the non-privileged user inside the distroless container. is script is responsible for updating the default themes then starts the Ghost application. This script is executed by the nonroot user thout privileges within the Distroless container, which updates default themes and starts the Ghost application, operation performed to the distroless container in runtime. [entrypoint.js](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/entrypoint.js)
+*Note*: You can host multiple Ghost instances by replacing the Namespace specification in each manifest file.
 
-## Installation Instructions
+## **Installation Instructions (Production)**
 
-### 0. Clone the repository or fork it
+Follow these steps to deploy Ghost on your Kubernetes cluster.
 
-  ```bash
-  ## Clone the repository
-  git clone https://github.com/sredevopsorg/ghost-on-kubernetes.git --depth 1 --branch main --single-branch --no-tags
-  ## Change directory
-  cd ghost-on-kubernetes
-  ## Create a new branch for your changes (optional but   recommended).
-  git checkout -b my-branch --no-track --detach
-  ```
+### **Prerequisites**
 
-### 1. Check the example configurations
+1. A functioning Kubernetes cluster (kubectl configured).  
+2. A provisioned StorageClass (required for PVCs).
 
-- There are some example configuration files in the [examples](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/examples/) directory. We use the stored configuration as a `kind: Secret` in the `ghost-on-kubernetes` namespace for Ghost and MySQL configuration. There are two example configuration files:
-  - `config.development.sample.yaml`: This configuration file is for the Ghost development environment. It uses SQLite as the database. It can be useful if you want to test the Ghost configuration before implementing it in a production environment.
-  - `config.production.sample.yaml`: This configuration file is for the Ghost production environment. It uses MySQL 8, and is the recommended configuration for production environments. It requires a valid top-level domain (TLD) and [configuration for Ingress to access Ghost from the Internet](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/07-ingress.yaml).
-- If you need more information on the configuration, check the [official Ghost documentation](https://ghost.org/docs/config/#custom-configuration-files).
+### **0. Clone (or fork) the Repository**
 
-### 2. Edit the default values and make changes as needed
-
-Remember to edit the values according to your needs, the details for every files are provided on each manifest file inside the [deploy folder](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/) and the following steps.
-
-### Understanding the Ghost Deployment Architecture on Kubernetes
-
-Deploying a sophisticated application like Ghost on Kubernetes involves orchestrating several components. Let's break down the essential Kubernetes resources we'll use:
-
-### Namespaces: Isolating Our Ghost Instance
-
-Namespaces in Kubernetes provide a logical separation of resources. We'll use the `ghost-on-kubernetes` namespace to contain all resources related to our Ghost deployment. This approach enhances organization and prevents resource conflicts with other applications running on the same cluster.
-
-> _*Note*: You can even host multiple Ghost instances on the same cluster by replacing the Namespace specification in each manifest file._
-
-Full file: [deploy/00-namespace.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/00-namespace.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ghost-on-kubernetes
-  labels:
-    app: ghost-on-kubernetes
-    # ... other labels
+```bash
+## Clone the repository  
+git clone https://github.com/sredevopsorg/ghost-on-kubernetes.git --depth 1 --branch main --single-branch --no-tags  
+## Change directory  
+cd ghost-on-kubernetes
 ```
 
-### Secrets: Securely Storing your Ghost Configuration
+### **1. Review and Configure**
 
-Secrets in Kubernetes allow us to store and manage sensitive data, such as database credentials and TLS certificates, securely. We'll use the following Secrets:
+Review the example configuration files and modify the manifests in the deploy/ folder to suit your environment (e.g., storage class, domain name, secret values).
 
-- `ghost-config-prod`: Stores the Ghost configuration, including database connection details and mail server settings.
-- `ghost-on-kubernetes-mysql-env`: Contains environment variables for the MySQL database, including the database name, username, and password.
-- `tls-secret`: Holds the TLS certificate and key for enabling HTTPS on our Ghost blog.
+* **Configurations:** Check the example configuration files in the [examples/](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/examples/) directory:  
+  * config.production.sample.yaml: Recommended configuration using MySQL 8. Requires a valid top-level domain (TLD) for the url field and Ingress configuration.  
+  * config.development.sample.yaml: Uses SQLite for testing environments.  
+* **Official Ghost Docs:** Refer to the [official Ghost documentation](https://ghost.org/docs/config/#custom-configuration-files) for detailed configuration options.
 
-Full file: [deploy/01-mysql-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-mysql-config.yaml)
+### **2. Deployment Sequence**
 
-Full file: [deploy/04-ghost-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/04-ghost-config.yaml)
+It is **crucial** to apply the manifests in the correct order to ensure dependency resolution (especially the database components).
 
-Full file: [deploy/01-tls.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-tls.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ghost-config-prod
-  namespace: ghost-on-kubernetes
-  # ... other metadata
-type: Opaque
-stringData:
-  config.production.json: |-
-    {
-      # ... Ghost configuration
-    }
-```
-
-### PersistentVolumeClaims: Persistent Storage for Our Blog
-
-PersistentVolumeClaims (PVCs) in Kubernetes enable us to request persistent storage volumes. We'll use two PVCs:
-
-- `k8s-ghost-content`: Provides persistent storage for Ghost's content, including images, themes, and uploaded files.
-- `ghost-on-kubernetes-mysql-pvc`: Offers persistent storage for the MySQL database, ensuring data persistence across pod restarts and reschedulings.
-
-Full file: [deploy/02-pvc.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/02-pvc.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: k8s-ghost-content
-  namespace: ghost-on-kubernetes
-  # ... other metadata
-spec:
-  # ... PVC specification
-```
-
-### Services: Exposing Ghost and MySQL Within the Cluster
-
-Services in Kubernetes provide a way to expose our applications running on a set of pods as a network service. We'll define two services:
-
-- `ghost-on-kubernetes-service`: Exposes the Ghost application internally within the cluster on port 2368.
-- `ghost-on-kubernetes-mysql-service`: Exposes the MySQL database internally on port 3306, allowing the Ghost application to connect to the database.
-
-Full file: [deploy/03-service.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/03-service.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: v1
-kind: Service
-metadata:
-  name: ghost-on-kubernetes-service
-  namespace: ghost-on-kubernetes
-  # ... other metadata
-spec:
-  # ... Service specification
-```
-
-### StatefulSet: Managing the MySQL Database
-
-A StatefulSet in Kubernetes is designed to manage stateful applications, such as databases, that require persistent storage and stable network identities. We'll use a StatefulSet to deploy a single replica of the MySQL database.
-
-Full file: [deploy/05-mysql.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/05-mysql.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: ghost-on-kubernetes-mysql
-  namespace: ghost-on-kubernetes
-  # ... other metadata
-spec:
-  # ... StatefulSet specification
-```
-
-### Deployment: Managing the Ghost Application
-
-Deployments in Kubernetes manage the deployment and scaling of stateless applications. We'll use a Deployment to deploy a single replica of the Ghost application.
-
-Full file: [deploy/06-ghost-deployment.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/06-ghost-deployment.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ghost-on-kubernetes
-  namespace: ghost-on-kubernetes
-  # ... other metadata
-spec:
-  # ... Deployment specification
-```
-
-### Ingress: Exposing Ghost to the Outside World
-
-An Ingress resource in Kubernetes acts as a reverse proxy, routing external traffic to services within the cluster. We'll use an Ingress to expose our Ghost blog to the internet using a domain name.
-
-File: [deploy/07-ingress.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/07-ingress.yaml)
-
-```yaml
-# Source code example excerpt:
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ghost-on-kubernetes-ingress
-  namespace: ghost-on-kubernetes
-  # ... other metadata
-spec:
-  # ... Ingress specification
-```
-
-## Bringing It All Together: Deploying Ghost on Kubernetes
-
-With our Kubernetes resources defined, we can now deploy Ghost on our cluster. Follow these general steps:
-
-_IMPORTANT NOTE_: You need to apply those commands or deploy files in order, or you could face inconsistences on your MySQL StatefulSet and/or other components.
-
-1. **Create the Namespace:**
+1. **Create the Namespace:**  
 
    ```bash
-   kubectl apply -f deploy/00-namespace.yaml
-   ```
+    kubectl apply -f deploy/00-namespace.yaml
+    ```
 
-2. **Create the Secrets:**
+2. **Create Secrets (Credentials and Config):**  
 
    ```bash
-   kubectl apply -f deploy/01-mysql-config.yaml
-   kubectl apply -f deploy/04-ghost-config.yaml
+   # IMPORTANT: Customize these secrets before applying  
+   kubectl apply -f deploy/01-mysql-config.yaml  
+   kubectl apply -f deploy/04-ghost-config.yaml  
    kubectl apply -f deploy/01-tls.yaml
    ```
 
-3. **Create the PersistentVolumeClaims:**
+3. **Create Persistent Storage and Services:**  
 
    ```bash
-   kubectl apply -f deploy/02-pvc.yaml
-   ```
-
-4. **Create the Services:**
-
-   ```bash
+   kubectl apply -f deploy/02-pvc.yaml  
    kubectl apply -f deploy/03-service.yaml
    ```
 
-5. **Deploy the MySQL Database:**
+4. **Deploy MySQL Database (StatefulSet):**  
 
    ```bash
+   # Wait for the MySQL PVC to be bound  
    kubectl apply -f deploy/05-mysql.yaml
    ```
 
-6. **Deploy the Ghost Application:**
+5. **Deploy the Ghost Application (Deployment):**  
 
-   ```bash
+    ```bash
+    # Wait for MySQL to be ready before starting
    kubectl apply -f deploy/06-ghost-deployment.yaml
    ```
 
-7. **Expose Ghost with Ingress (Optional):**
+6. **Expose Ghost with Ingress (Optional/Recommended):**  
 
-   ```bash
-   kubectl apply -f deploy/07-ingress.yaml
-   ```
+    ```bash
+    # Routes external traffic to the Ghost Service
+    kubectl apply -f deploy/07-ingress.yaml
+    ```
 
-## Your Ghost Blog is deployed! 🎉
+## **Your Ghost Blog is Deployed!**
 
-Congratulations! You've successfully deployed Ghost on a Kubernetes cluster. This setup provides a robust and scalable foundation for your blogging platform. Remember to customize the configurations, such as storage class, resource limits, and domain name, to suit your specific requirements.
+Congratulations! You have deployed a highly secure and scalable Ghost v6 instance on Kubernetes.
 
-## A final trick: Access Ghost on Kubernetes without a domain name
+### **Accessing Without a Domain Name (Testing)**
 
-If you want to use a port forwarding to preview the website, be sure to configure both url and admin URLs in the config file as `http://localhost:2368/`, resttart the pod and then run the kubectl port-forwarding like:
+To preview the website without configuring Ingress or a TLD, you can use port forwarding:
+
+1. Temporarily configure both url and admin URLs in your config.production.json Secret to use `http://localhost:2368/`.  
+2. Restart the Ghost pod(s) after updating the Secret.  
+3. Run the port-forwarding command:  
 
   ```bash
   kubectl port-forward -n ghost-on-kubernetes services ghost-on-kubernetes-service 2368:2368
@@ -284,10 +146,11 @@ We welcome contributions from the community! Please check the [CONTRIBUTING.md](
 
 ## License and Credits
 
-- This project is licensed under the MIT License. Please check the [LICENSE](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/LICENSE) file for more information.
-- The Ghost CMS is licensed under the [MIT License](https://github.com/TryGhost/Ghost/blob/main/LICENSE).
-- The node image and the Distroless image are licensed by their respective owners.
+* This project is licensed under the MIT License. Please check the [LICENSE](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/LICENSE) file for more information.
+* The Ghost CMS is licensed under the [MIT License](https://github.com/TryGhost/Ghost/blob/main/LICENSE).
+* The node image and the Distroless image are licensed by their respective owners.
 
 ## Star History
 
 ![Star History Chart](https://api.star-history.com/svg?repos=sredevopsorg/ghost-on-kubernetes&type=Date&theme=dark)
+

--- a/deploy/00-namespace.yaml
+++ b/deploy/00-namespace.yaml
@@ -6,6 +6,6 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: ghost-on-kubernetes
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: namespace
     app.kubernetes.io/part-of: ghost-on-kubernetes

--- a/deploy/01-mysql-config.yaml
+++ b/deploy/01-mysql-config.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes-mysql
     app.kubernetes.io/name: ghost-on-kubernetes-mysql-env
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: database-secret
     app.kubernetes.io/part-of: ghost-on-kubernetes
     

--- a/deploy/01-tls.yaml
+++ b/deploy/01-tls.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: tls-secret
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: tls-secret
     app.kubernetes.io/part-of: ghost-on-kubernetes
     

--- a/deploy/02-pvc.yaml
+++ b/deploy/02-pvc.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: k8s-ghost-content
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: storage
     app.kubernetes.io/part-of: ghost-on-kubernetes
     
@@ -34,7 +34,7 @@ metadata:
     app: ghost-on-kubernetes-mysql
     app.kubernetes.io/name: ghost-on-kubernetes-mysql-pvc
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: database-storage
     app.kubernetes.io/part-of: ghost-on-kubernetes
     

--- a/deploy/03-service.yaml
+++ b/deploy/03-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: ghost-on-kubernetes-service
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: service-frontend
     app.kubernetes.io/part-of: ghost-on-kubernetes
     
@@ -32,7 +32,7 @@ metadata:
     app: ghost-on-kubernetes-mysql
     app.kubernetes.io/name: ghost-on-kubernetes-mysql-service
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: service-database
     app.kubernetes.io/part-of: ghost-on-kubernetes
     

--- a/deploy/04-ghost-config.yaml
+++ b/deploy/04-ghost-config.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: ghost-config-prod
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: ghost-config
     app.kubernetes.io/part-of: ghost-on-kubernetes
 type: Opaque

--- a/deploy/05-mysql.yaml
+++ b/deploy/05-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes-mysql
     app.kubernetes.io/name: ghost-on-kubernetes-mysql
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: database
     app.kubernetes.io/part-of: ghost-on-kubernetes
     

--- a/deploy/06-ghost-deployment.yaml
+++ b/deploy/06-ghost-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: ghost-on-kubernetes
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.92'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: ghost
     app.kubernetes.io/part-of: ghost-on-kubernetes
     
@@ -94,6 +94,8 @@ spec:
 
       containers:
       - name: ghost-on-kubernetes
+        # For development, you can use the following image:
+        # image: ghcr.io/sredevopsorg/ghost-on-kubernetes:latest-dev
         image: ghcr.io/sredevopsorg/ghost-on-kubernetes:main
         imagePullPolicy: Always
         ports:

--- a/deploy/07-ingress.yaml
+++ b/deploy/07-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     app: ghost-on-kubernetes
     app.kubernetes.io/name: ghost-on-kubernetes-ingress
     app.kubernetes.io/instance: ghost-on-kubernetes
-    app.kubernetes.io/version: '5.59'
+    app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: ingress
     app.kubernetes.io/part-of: ghost-on-kubernetes
     


### PR DESCRIPTION
- Updated README.md to reflect the new version and enhance security and efficiency highlights.
- Changed version labels from 5.92 to 6.0 across all Kubernetes manifest files for consistency.
- Improved security features including non-root execution and distroless images.
- Added details about the new entrypoint script and init container for better deployment practices.
- Updated deployment instructions and configuration examples for Ghost v6.