### PR TITLE
ci: Automate building new '-docker' releases when there's a release.

### DIFF
--- a/.github/workflows/check-ghost-releases.yaml
+++ b/.github/workflows/check-ghost-releases.yaml
@@ -6,9 +6,6 @@ on:
   schedule:
     - cron: '0 */6 * * *'  # Every 6 hours
   workflow_dispatch:  # Allow manual trigger
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -17,7 +14,7 @@ jobs:
   check-and-trigger:
     runs-on: ubuntu-latest
     permissions:
-      actions: write  # Required to trigger other workflows
+#      actions: write  # Required to trigger other workflows
       contents: read
     
     steps:


### PR DESCRIPTION
This PR was generated with AI assistance and needs testing by someone with permission to make builds.

If you have the `gh` CLI (It's nice, I recommend it!), you can test it like this:

```
gh workflow run check-ghost-releases.yaml
```

Currently on building `-docker` builds are automated. You may wish to extend this to building the main and `-dev` builds as well.
