### PR TITLE
Add native application level redis caching support

### DIFF
--- a/Charts/ghost-on-kubernetes/Chart.yaml
+++ b/Charts/ghost-on-kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ghost-on-kubernetes
 description: Ghost v6 on Kubernetes (k8s, k3s, etc) with our hardened distroless rootless custom image by SREDevOps.org
 type: application
-version: "1.0.7"
-appVersion: "6.20.0"
+version: "1.0.8"
+appVersion: "6.44.1"
 keywords:
   - ghost
   - cms

--- a/Charts/ghost-on-kubernetes/README.md
+++ b/Charts/ghost-on-kubernetes/README.md
@@ -78,6 +78,36 @@ helm install my-ghost ./ghost-on-kubernetes \
   --set persistence.ghost.storageClassName=your-storage-class
 ```
 
+### With Valkey Application Caching
+
+Enable the internal non-root Valkey deployment to offload public Content API blocks, analytics, and asset metadata maps:
+Install from the Helm chart repository (recommended):
+
+```bash
+helm repo add sredevopsorg https://sredevopsorg.github.io/ghost-on-kubernetes
+helm repo update
+helm install my-ghost sredevopsorg/ghost-on-kubernetes \
+  --namespace ghost \
+  --create-namespace \
+  --set ghost.url=https://yourdomain.tld \
+  --set valkey.enabled=true \
+  --set valkey.auth.enabled=true \
+  --set valkey.auth.password=your-password \
+  --set persistence.valkey.storageClassName=your-storage-class
+```
+
+Or from the local chart:
+
+```bash
+helm install my-ghost ./ghost-on-kubernetes \
+  --namespace ghost \
+  --create-namespace \
+  --set ghost.url=https://yourdomain.tld \
+  --set valkey.enabled=true \
+  --set valkey.auth.enabled=true \
+  --set valkey.auth.password=your-password \
+  --set persistence.valkey.storageClassName=your-storage-class
+
 ### With cert-manager for TLS
 
 Install from the Helm chart repository (recommended):
@@ -149,12 +179,19 @@ helm install my-ghost ./ghost-on-kubernetes \
 | `ghost.adminUrl` | Ghost admin URL | `https://yourdomain.tld` |
 | `mysql.enabled` | Deploy MySQL StatefulSet | `true` |
 | `mysql.external.host` | External MySQL host | `external-mysql-host` |
+| `valkey.enabled` | Deploy internal non-root Valkey cache | `false` |
+| `valkey.auth.enabled` | Enable password authentication for internal Valkey | `false` |
+| `valkey.external.enabled` | Route application caching to an external Redis/Valkey instance | `false` |
+| `valkey.external.host` | Target host endpoint for external caching | `"external-valkey-host"` |
+| `valkey.external.keyPrefix` | Base keyspace tracking prefix string | `"ghost"` |
 | `persistence.ghost.enabled` | Enable Ghost content persistence | `true` |
 | `persistence.ghost.storageClassName` | StorageClass for Ghost content | `""` |
 | `persistence.ghost.accessMode` | Access mode for Ghost PVC | `ReadWriteOnce` |
 | `persistence.ghost.size` | Ghost content volume size | `1Gi` |
 | `persistence.mysql.enabled` | Enable MySQL persistence | `true` |
 | `persistence.mysql.storageClassName` | StorageClass for MySQL | `""` |
+| `persistence.valkey.enabled` | Enable persistent storage for internal Valkey state | `true` |
+| `persistence.valkey.storageClassName` | StorageClass for Valkey | `""` |
 | `ingress.enabled` | Enable Ingress | `true` |
 | `ingress.className` | Ingress class name | `traefik` |
 | `ingress.preset` | Ingress preset (traefik/nginx/custom) | `traefik` |
@@ -197,6 +234,15 @@ mysql:
     requests:
       cpu: 300m
       memory: 500Mi
+
+valkey:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 ```
 
 ### High Availability Setup
@@ -332,6 +378,11 @@ mysql:
     password: secure-password
     rootPassword: secure-root-password
 
+valkey:
+  enabled: true
+  auth:
+    password: secure-password
+
 persistence:
   ghost:
     storageClassName: fast-ssd
@@ -339,6 +390,9 @@ persistence:
   mysql:
     storageClassName: standard
     size: 10Gi
+  valkey:
+    storageClassName: standard
+    size: 2Gi
 
 ingress:
   className: nginx

--- a/Charts/ghost-on-kubernetes/templates/NOTES.txt
+++ b/Charts/ghost-on-kubernetes/templates/NOTES.txt
@@ -37,11 +37,24 @@ Your Ghost CMS has been deployed to namespace: {{ .Release.Namespace }}
 3. Using external MySQL at: {{ .Values.mysql.external.host }}:{{ .Values.mysql.external.port }}
 {{- end }}
 
-4. Monitor Ghost logs:
+{{- if or .Values.valkey.enabled .Values.valkey.external.enabled }}
+{{- if .Values.valkey.enabled }}
+
+4. Valkey is deployed internally as an application cache.
+   Connection Endpoint: {{ include "ghost-on-kubernetes.valkey.host" . }}:{{ include "ghost-on-kubernetes.valkey.port" . }}
+   Authentication: {{ if .Values.valkey.auth.enabled }}Enabled (Secret: {{ include "ghost-on-kubernetes.fullname" . }}-valkey){{ else }}Disabled{{ end }}
+{{- else }}
+
+4. Valkey caching is routed to an external instance.
+   Target Endpoint: {{ .Values.valkey.external.host }}:{{ .Values.valkey.external.port }}
+{{- end }}
+{{- end }}
+
+5. Monitor Ghost logs:
 
    kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "ghost-on-kubernetes.name" . }} -f
 
-5. To complete Ghost setup, visit your domain and follow the admin setup wizard.
+6. To complete Ghost setup, visit your domain and follow the admin setup wizard.
 
 {{- if and .Values.mysql.enabled (not .Values.persistence.mysql.enabled) }}
 

--- a/Charts/ghost-on-kubernetes/templates/_helpers.tpl
+++ b/Charts/ghost-on-kubernetes/templates/_helpers.tpl
@@ -115,3 +115,68 @@ MySQL password
 {{- end }}
 {{- end }}
 
+{{/*
+Valkey host
+*/}}
+{{- define "ghost-on-kubernetes.valkey.host" -}}
+{{- if .Values.valkey.enabled }}
+{{- printf "%s-valkey-service" (include "ghost-on-kubernetes.fullname" .) }}
+{{- else }}
+{{- .Values.valkey.external.host }}
+{{- end }}
+{{- end }}
+
+{{/*
+Valkey port
+*/}}
+{{- define "ghost-on-kubernetes.valkey.port" -}}
+{{- if .Values.valkey.enabled }}
+{{- default 6379 .Values.service.valkey.port }}
+{{- else }}
+{{- .Values.valkey.external.port }}
+{{- end }}
+{{- end }}
+
+{{/*
+Valkey database
+*/}}
+{{- define "ghost-on-kubernetes.valkey.database" -}}
+{{- if .Values.valkey.enabled }}
+{{- default 0 .Values.valkey.database }}
+{{- else }}
+{{- .Values.valkey.external.database }}
+{{- end }}
+{{- end }}
+
+{{/*
+Valkey key prefix
+*/}}
+{{- define "ghost-on-kubernetes.valkey.keyPrefix" -}}
+{{- if .Values.valkey.enabled }}
+{{- printf "ghost:" }}
+{{- else }}
+{{- printf "%s:" (trimSuffix ":" .Values.valkey.external.keyPrefix) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Valkey username
+*/}}
+{{- define "ghost-on-kubernetes.valkey.username" -}}
+{{- if .Values.valkey.enabled }}
+{{- .Values.valkey.auth.username }}
+{{- else }}
+{{- .Values.valkey.external.username }}
+{{- end }}
+{{- end }}
+
+{{/*
+Valkey password
+*/}}
+{{- define "ghost-on-kubernetes.valkey.password" -}}
+{{- if .Values.valkey.enabled }}
+{{- .Values.valkey.auth.password }}
+{{- else }}
+{{- .Values.valkey.external.password }}
+{{- end }}
+{{- end }}

--- a/Charts/ghost-on-kubernetes/templates/deployment-valkey.yaml
+++ b/Charts/ghost-on-kubernetes/templates/deployment-valkey.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.valkey.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost-on-kubernetes.fullname" . }}-valkey
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+    {{- include "ghost-on-kubernetes.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache
+spec:
+  replicas: {{ .Values.valkey.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+  template:
+    metadata:
+      labels:
+        app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+    spec:
+      initContainers:
+      - name: valkey-init
+        securityContext:
+          {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
+        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+        imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo 'Changing ownership of valkey data directory to 65532:65532'
+          chown -Rfv 65532:65532 /mnt/data || echo 'Error changing ownership of valkey data directory to 65532:65532'
+          echo 'Changing ownership of tmp mount directory to 65532:65532'
+          chown -Rfv 65532:65532 /mnt/tmp || echo 'Error changing ownership of tmp mount directory to 65532:65532'
+        volumeMounts:
+        - name: valkey-data
+          mountPath: /mnt/data
+          readOnly: false
+        - name: valkey-tmp
+          mountPath: /mnt/tmp
+          readOnly: false
+        resources:
+          {{- toYaml .Values.valkey.initResources | nindent 10 }}
+      containers:
+      - name: valkey
+        securityContext:
+          {{- toYaml .Values.valkey.securityContext | nindent 10 }}
+        image: "{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}"
+        imagePullPolicy: {{ .Values.valkey.image.pullPolicy }}
+        # Default Valkey images run as user 999; explicitly executing valkey-server points config data to our writable directories
+        command:
+        - valkey-server
+        - --dir
+        - /data
+        - --protected-mode
+        - "no"
+        {{- if .Values.valkey.auth.enabled }}
+        - --requirepass
+        - $(VALKEY_PASSWORD)
+        {{- end }}
+        {{- if .Values.valkey.auth.enabled }}
+        env:
+        - name: VALKEY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "ghost-on-kubernetes.fullname" . }}-valkey
+              key: valkey-password
+        {{- end }}
+        resources:
+          {{- toYaml .Values.valkey.resources | nindent 10 }}
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+          name: valkey
+        volumeMounts:
+        - name: valkey-data
+          mountPath: /data
+          readOnly: false
+        - name: valkey-tmp
+          mountPath: /tmp
+          readOnly: false
+      automountServiceAccountToken: false
+      {{- if .Values.valkey.affinity.enabled }}
+      affinity:
+        {{- $yaml := toYaml .Values.valkey.affinity | replace "enabled: true\n" "" | replace "enabled: true" "" }}
+        {{ $yaml | nindent 8 }}
+      {{- end }}
+
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      {{- if and .Values.persistence.valkey.enabled .Values.valkey.enabled }}
+      - name: valkey-data
+        persistentVolumeClaim:
+          claimName: {{ include "ghost-on-kubernetes.fullname" . }}-valkey-pvc
+      {{- else }}
+      - name: valkey-data
+        emptyDir:
+          sizeLimit: {{ .Values.volumes.valkeyData.sizeLimit | default "256Mi" }}
+      {{- end }}
+      - name: valkey-tmp
+        emptyDir:
+          sizeLimit: {{ .Values.volumes.valkeyTmp.sizeLimit | default "128Mi" }}
+{{- end }}

--- a/Charts/ghost-on-kubernetes/templates/deployment-valkey.yaml
+++ b/Charts/ghost-on-kubernetes/templates/deployment-valkey.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "ghost-on-kubernetes.labels" . | nindent 4 }}
     app.kubernetes.io/component: cache
 spec:
-  replicas: {{ .Values.valkey.replicaCount | default 1 }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ include "ghost-on-kubernetes.name" . }}-valkey
@@ -18,30 +18,6 @@ spec:
       labels:
         app: {{ include "ghost-on-kubernetes.name" . }}-valkey
     spec:
-      initContainers:
-      - name: valkey-init
-        securityContext:
-          {{- toYaml .Values.initContainer.securityContext | nindent 10 }}
-        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
-        imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-          echo 'Changing ownership of valkey data directory to 65532:65532'
-          chown -Rfv 65532:65532 /mnt/data || echo 'Error changing ownership of valkey data directory to 65532:65532'
-          echo 'Changing ownership of tmp mount directory to 65532:65532'
-          chown -Rfv 65532:65532 /mnt/tmp || echo 'Error changing ownership of tmp mount directory to 65532:65532'
-        volumeMounts:
-        - name: valkey-data
-          mountPath: /mnt/data
-          readOnly: false
-        - name: valkey-tmp
-          mountPath: /mnt/tmp
-          readOnly: false
-        resources:
-          {{- toYaml .Values.valkey.initResources | nindent 10 }}
       containers:
       - name: valkey
         securityContext:
@@ -88,6 +64,7 @@ spec:
       {{- end }}
 
       securityContext:
+        fsGroup: {{ .Values.valkey.securityContext.runAsGroup }}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
       {{- if and .Values.persistence.valkey.enabled .Values.valkey.enabled }}

--- a/Charts/ghost-on-kubernetes/templates/deployment.yaml
+++ b/Charts/ghost-on-kubernetes/templates/deployment.yaml
@@ -112,6 +112,13 @@ spec:
         env:
         - name: NODE_ENV
           value: production
+        {{- if and .Values.valkey.enabled .Values.valkey.auth.enabled }}
+        - name: VALKEY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "ghost-on-kubernetes.fullname" . }}-valkey
+              key: valkey-password
+        {{- end }}
         resources:
           {{- toYaml .Values.ghost.resources | nindent 10 }}
         volumeMounts:

--- a/Charts/ghost-on-kubernetes/templates/pvc.yaml
+++ b/Charts/ghost-on-kubernetes/templates/pvc.yaml
@@ -42,3 +42,24 @@ spec:
 {{- end }}
 
 ---
+{{- if and .Values.valkey.enabled .Values.persistence.valkey.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ghost-on-kubernetes.fullname" . }}-valkey-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+    {{- include "ghost-on-kubernetes.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache-storage
+spec:
+  {{- if .Values.persistence.valkey.storageClassName }}
+  storageClassName: {{ .Values.persistence.valkey.storageClassName | quote }}
+  {{- end }}
+  volumeMode: Filesystem
+  accessModes:
+    - {{ .Values.persistence.valkey.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.valkey.size }}
+{{- end }}

--- a/Charts/ghost-on-kubernetes/templates/secret-ghost-config.yaml
+++ b/Charts/ghost-on-kubernetes/templates/secret-ghost-config.yaml
@@ -49,9 +49,40 @@ stringData:
           "port": {{ include "ghost-on-kubernetes.mysql.port" . | quote }}
         }
       },
+      {{- if or .Values.valkey.enabled .Values.valkey.external.enabled }}
+      "hostSettings": {
+        "postsPublicCache": { "enabled": true },
+        "linkRedirectsPublicCache": { "enabled": true },
+        "tagsPublicCache": { "enabled": true },
+        "statsCache": { "enabled": true }
+      },
+      "adapters": {
+        "active": "Redis",
+        "cache": {
+          "Redis": {
+            "host": {{ include "ghost-on-kubernetes.valkey.host" . | quote }},
+            "port": {{ include "ghost-on-kubernetes.valkey.port" . }},
+            "db": {{ include "ghost-on-kubernetes.valkey.database" . }},
+            "ttl": {{ .Values.valkey.ttl.imageSizes | default 86400 }},
+            "keyPrefix": {{ include "ghost-on-kubernetes.valkey.keyPrefix" . | quote }}
+            {{- if or (and .Values.valkey.enabled .Values.valkey.auth.enabled) (and .Values.valkey.external.enabled .Values.valkey.external.password) }},
+            "username": {{ include "ghost-on-kubernetes.valkey.username" . | quote }},
+            "password": {{ include "ghost-on-kubernetes.valkey.password" . | quote }}
+            {{- end }}
+          }
+          {{- $adapterList := tuple "imageSizes" "gscan" "postsPublic" "tagsPublic" "linkRedirectsPublic" "stats" }}
+          {{- range $adapter := $adapterList }},
+          {{ $adapter | quote }}: {
+            "adapter": "Redis",
+            "ttl": {{ index $.Values.valkey.ttl $adapter | default 3600 }},
+            "keyPrefix": {{ printf "%s%s:" (include "ghost-on-kubernetes.valkey.keyPrefix" $) $adapter | toJson }}
+          }
+          {{- end }}
+        }
+      },
+      {{- end }}
       "process": "local",
       "paths": {
         "contentPath": "/home/nonroot/app/ghost/content"
       }
     }
-

--- a/Charts/ghost-on-kubernetes/templates/secret-valkey.yaml
+++ b/Charts/ghost-on-kubernetes/templates/secret-valkey.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.valkey.enabled .Values.valkey.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ghost-on-kubernetes.fullname" . }}-valkey
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+    {{- include "ghost-on-kubernetes.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache-secret
+type: Opaque
+stringData:
+  valkey-password: {{ .Values.valkey.auth.password | quote }}
+{{- end }}

--- a/Charts/ghost-on-kubernetes/templates/service.yaml
+++ b/Charts/ghost-on-kubernetes/templates/service.yaml
@@ -41,3 +41,25 @@ spec:
   selector:
     app: {{ include "ghost-on-kubernetes.name" . }}-mysql
 {{- end }}
+---
+{{- if .Values.valkey.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost-on-kubernetes.fullname" . }}-valkey-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+    {{- include "ghost-on-kubernetes.labels" . | nindent 4 }}
+    app.kubernetes.io/component: service-cache
+spec:
+  ports:
+  - port: {{ .Values.service.valkey.port }}
+    protocol: TCP
+    targetPort: valkey
+    name: valkey
+  type: {{ .Values.service.valkey.type }}
+  clusterIP: None
+  selector:
+    app: {{ include "ghost-on-kubernetes.name" . }}-valkey
+{{- end }}

--- a/Charts/ghost-on-kubernetes/values.schema.json
+++ b/Charts/ghost-on-kubernetes/values.schema.json
@@ -50,6 +50,58 @@
         }
       }
     },
+    "valkey": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy Valkey cache Deployment"
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of Valkey pod replicas"
+        },
+        "ttl": {
+          "type": "object",
+          "description": "Cache TTL values in seconds",
+          "properties": {
+            "imageSizes": {"type": "integer", "minimum": 0},
+            "gscan": {"type": "integer", "minimum": 0},
+            "postsPublic": {"type": "integer", "minimum": 0},
+            "tagsPublic": {"type": "integer", "minimum": 0},
+            "linkRedirectsPublic": {"type": "integer", "minimum": 0},
+            "stats": {"type": "integer", "minimum": 0}
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable Valkey authentication"
+            },
+            "username": {"type": "string"},
+            "password": {"type": "string"}
+          }
+        },
+        "external": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Use external Valkey/Redis instance"
+            },
+            "host": {"type": "string"},
+            "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+            "database": {"type": "integer", "minimum": 0},
+            "keyPrefix": {"type": "string"},
+            "username": {"type": "string"},
+            "password": {"type": "string"}
+          }
+        }
+      }
+    },
     "persistence": {
       "type": "object",
       "properties": {

--- a/Charts/ghost-on-kubernetes/values.yaml
+++ b/Charts/ghost-on-kubernetes/values.yaml
@@ -136,6 +136,80 @@ mysql:
                 values:
                   - "true"
 
+# Valkey configuration
+valkey:
+  # Enable/disable internal cluster Valkey deployment
+  enabled: false
+
+  replicaCount: 1
+
+  # Global cache entry expiration in seconds (Default: 1 hour)
+  ttl:
+    imageSizes: 86400
+    gscan: 43200
+    postsPublic: 1800
+    tagsPublic: 3600
+    linkRedirectsPublic: 7200
+    stats: 900
+
+  image:
+    repository: docker.io/valkey/valkey
+    tag: "9.1-alpine"
+    pullPolicy: IfNotPresent
+
+  # Authentication configuration for internal deployment
+  auth:
+    enabled: false
+    username: "default"
+    password: "changeme"
+
+  # External Valkey/Redis configuration (used when valkey.enabled=false)
+  external:
+    enabled: false
+    host: "external-valkey-host"
+    port: 6379
+    database: 0
+    keyPrefix: "ghost"
+    username: "default"
+    password: "changeme"
+
+  # Resource limits for the internal deployment
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Init container resources for volume mounting permission fixes
+  initResources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 0m
+      memory: 0Mi
+
+  # Security context matching project non-root standards
+  securityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 65532
+
+  # valkey Node affinity (optional)
+  affinity:
+    enabled: false
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: In
+                values:
+                  - "true"
+
 # Persistence configuration
 persistence:
   ghost:
@@ -152,6 +226,12 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
 
+  valkey:
+    enabled: true
+    storageClassName: ""
+    accessMode: ReadWriteOnce
+    size: 1Gi
+
 # Service configuration
 service:
   type: ClusterIP
@@ -160,6 +240,10 @@ service:
   mysql:
     type: ClusterIP
     port: 3306
+
+  valkey:
+    type: ClusterIP
+    port: 6379
 
 # Ingress configuration
 ingress:
@@ -237,6 +321,10 @@ volumes:
   mysqlTmp:
     sizeLimit: 128Mi
   mysqlSocket:
+    sizeLimit: 128Mi
+  valkeyData:
+    sizeLimit: 256Mi
+  valkeyTmp:
     sizeLimit: 128Mi
 
 # Pod security context

--- a/Charts/ghost-on-kubernetes/values.yaml
+++ b/Charts/ghost-on-kubernetes/values.yaml
@@ -141,8 +141,6 @@ valkey:
   # Enable/disable internal cluster Valkey deployment
   enabled: false
 
-  replicaCount: 1
-
   # Global cache entry expiration in seconds (Default: 1 hour)
   ttl:
     imageSizes: 86400
@@ -159,7 +157,7 @@ valkey:
 
   # Authentication configuration for internal deployment
   auth:
-    enabled: false
+    enabled: true
     username: "default"
     password: "changeme"
 
@@ -196,7 +194,8 @@ valkey:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    runAsUser: 65532
+    runAsUser: 999
+    runAsGroup: 1000
 
   # valkey Node affinity (optional)
   affinity:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This repository implements Ghost CMS v6.xx.x from [@TryGhost (Official)](https:/
 
 ### **Enhanced Security**
 
-* **Non-Root Execution:** Both the Ghost and MySQL components run exclusively as a non-root user (UID/GID 65532) in Kubernetes, preventing potential privilege escalation attacks.  
-* **Distroless Runtime:** We utilize **Google Container Tools Distroless Debian 13 - NodeJS 22** as the final runtime environment. Distroless images contain only the required application and language dependencies, **excluding shells and package managers**, making them substantially more secure and reducing the attack surface.  
-* **Vulnerability Reduction:** By replacing gosu with a native container execution flow and adopting Distroless, we removed several critical vulnerabilities reported in the original Ghost image:  
+* **Non-Root Execution:** Both the Ghost and MySQL components run exclusively as a non-root user (UID/GID 65532) in Kubernetes, preventing potential privilege escalation attacks.
+* **Distroless Runtime:** We utilize **Google Container Tools Distroless Debian 13 - NodeJS 22** as the final runtime environment. Distroless images contain only the required application and language dependencies, **excluding shells and package managers**, making them substantially more secure and reducing the attack surface.
+* **Vulnerability Reduction:** By replacing gosu with a native container execution flow and adopting Distroless, we removed several critical vulnerabilities reported in the original Ghost image:
   * **Result:** This change alone reduced **6 critical vulnerabilities** and **34 high vulnerabilities** reported by Docker Scout in the official image.
 
 **Example Security Reports:**
@@ -25,13 +25,13 @@ This repository implements Ghost CMS v6.xx.x from [@TryGhost (Official)](https:/
 
 ### **Performance & Architecture**
 
-* **Custom Build Artifacts:** We maintain two distinct Dockerfiles for production and development:  
-  * **Production Image:** The main image built using our hardened, multi-stage build process. See the [Dockerfile](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile).  
-  * **Development Image:** A variant tailored for testing, which bundles SQLite support. See the [Dockerfile-dev](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile-dev).  
-* **Multi-Arch Support:** Images are built for both amd64 and arm64 architectures.  
-* **Multi-Stage Build:** We use the official Node 22 Jod LTS image for building, which significantly reduces the final image size and improves security by removing unnecessary build components.  
-* **Updated Ghost v6 & NodeJS 22 LTS:** Using the latest stable versions for security and performance.  
-* **Robust Entrypoint (entrypoint.js):** A custom Node.js entrypoint script, executed by the unprivileged user, handles necessary runtime operations like updating default themes before starting the Ghost application. The script can be reviewed here: [entrypoint.js](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/entrypoint.js).  
+* **Custom Build Artifacts:** We maintain two distinct Dockerfiles for production and development:
+  * **Production Image:** The main image built using our hardened, multi-stage build process. See the [Dockerfile](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile).
+  * **Development Image:** A variant tailored for testing, which bundles SQLite support. See the [Dockerfile-dev](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Dockerfile-dev).
+* **Multi-Arch Support:** Images are built for both amd64 and arm64 architectures.
+* **Multi-Stage Build:** We use the official Node 22 Jod LTS image for building, which significantly reduces the final image size and improves security by removing unnecessary build components.
+* **Updated Ghost v6 & NodeJS 22 LTS:** Using the latest stable versions for security and performance.
+* **Robust Entrypoint (entrypoint.js):** A custom Node.js entrypoint script, executed by the unprivileged user, handles necessary runtime operations like updating default themes before starting the Ghost application. The script can be reviewed here: [entrypoint.js](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/entrypoint.js).
 * **Dedicated Init Container:** The deployment includes an initContainer to handle directory creation, correct ownership (UID/GID 65532), and permission setting prior to the main Ghost container launch, ensuring seamless operation inside the Distroless container.
 
 ## **Deployment Architecture Overview**
@@ -42,10 +42,11 @@ This project provides complete Kubernetes manifest files (deploy/) to run a prod
 | :---- | :---- | :---- |
 | **Namespace** | ghost-on-kubernetes | Provides logical isolation for all components. (File: [00-namespace.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/00-namespace.yaml)) |
 | **StatefulSet** | ghost-on-kubernetes-mysql | Manages the MySQL 8 database, ensuring stable networking and persistent storage. (File: [05-mysql.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/05-mysql.yaml)) |
+| **Deployment** | ghost-on-kubernetes-valkey | Manages the Valkey cache pods for improved performance. (File: [05-valkey.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/05-valkey.yaml)) |
 | **Deployment** | ghost-on-kubernetes | Manages the Ghost v6 application pods. (File: [06-ghost-deployment.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/06-ghost-deployment.yaml)) |
-| **Services** | ghost-on-kubernetes-service, ghost-on-kubernetes-mysql-service | Exposes Ghost (2368) and MySQL (3306) internally within the cluster. (File: [03-service.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/03-service.yaml)) |
-| **PersistentVolumeClaims (PVC)** | k8s-ghost-content, ghost-on-kubernetes-mysql-pvc | Requests persistent storage for Ghost content (themes, images) and MySQL data. (File: [02-pvc.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/02-pvc.yaml)) |
-| **Secrets** | ghost-config-prod, ghost-on-kubernetes-mysql-env, tls-secret | Securely stores Ghost configuration, database credentials, and TLS certificates (optional). (Files: [01-mysql-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-mysql-config.yaml), [04-ghost-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/04-ghost-config.yaml), [01-tls.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-tls.yaml)) |
+| **Services** | ghost-on-kubernetes-service, ghost-on-kubernetes-mysql-service, ghost-on-kubernetes-valkey-service | Exposes Ghost (2368), MySQL (3306), and Valkey (6379) internally within the cluster. (File: [03-service.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/03-service.yaml)) |
+| **PersistentVolumeClaims (PVC)** | k8s-ghost-content, ghost-on-kubernetes-mysql-pvc, ghost-on-kubernetes-valkey-pvc | Requests persistent storage for Ghost content (themes, images), MySQL data, and Valkey cache data. (File: [02-pvc.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/02-pvc.yaml)) |
+| **Secrets** | ghost-config-prod, ghost-on-kubernetes-mysql-env, ghost-on-kubernetes-valkey-env, tls-secret | Securely stores Ghost configuration, database credentials, Valkey credentials, and TLS certificates (optional). (Files: [01-mysql-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-mysql-config.yaml), [01-valkey-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-valkey-config.yaml), [04-ghost-config.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/04-ghost-config.yaml), [01-tls.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/01-tls.yaml)) |
 | **Ingress** | ghost-on-kubernetes-ingress | Exposes the Ghost application to the outside world via HTTP/HTTPS (requires a TLD). (File: [07-ingress.yaml](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/deploy/07-ingress.yaml)) |
 
 *Note*: You can host multiple Ghost instances by replacing the Namespace specification in each manifest file.
@@ -56,15 +57,15 @@ Follow these steps to deploy Ghost on your Kubernetes cluster.
 
 ### **Prerequisites**
 
-1. A functioning Kubernetes cluster (kubectl configured).  
+1. A functioning Kubernetes cluster (kubectl configured).
 2. A provisioned StorageClass (required for PVCs).
 
 ### **0. Clone (or fork) the Repository**
 
 ```bash
-## Clone the repository  
-git clone https://github.com/sredevopsorg/ghost-on-kubernetes.git --depth 1 --branch main --single-branch --no-tags  
-## Change directory  
+## Clone the repository
+git clone https://github.com/sredevopsorg/ghost-on-kubernetes.git --depth 1 --branch main --single-branch --no-tags
+## Change directory
 cd ghost-on-kubernetes
 ```
 
@@ -72,9 +73,9 @@ cd ghost-on-kubernetes
 
 Review the example configuration files and modify the manifests in the deploy/ folder to suit your environment (e.g., storage class, domain name, secret values).
 
-* **Configurations:** Check the example configuration files in the [examples/](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/examples/) directory:  
-  * config.production.sample.yaml: Recommended configuration using MySQL 8. Requires a valid top-level domain (TLD) for the url field and Ingress configuration.  
-  * config.development.sample.yaml: Uses SQLite for testing environments.  
+* **Configurations:** Check the example configuration files in the [examples/](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/examples/) directory:
+  * config.production.sample.yaml: Recommended configuration using MySQL 8. Requires a valid top-level domain (TLD) for the url field and Ingress configuration.
+  * config.development.sample.yaml: Uses SQLite for testing environments.
 * **Official Ghost Docs:** Refer to the [official Ghost documentation](https://ghost.org/docs/config/#custom-configuration-files) for detailed configuration options.
 
 ### **2. Deployment Sequence**
@@ -93,43 +94,45 @@ helm install my-ghost sredevopsorg/ghost-on-kubernetes \
   --set persistence.ghost.storageClassName=your-storage-class
 ```
 
-1. **Create the Namespace:**  
+1. **Create the Namespace:**
 
    ```bash
     kubectl apply -f deploy/00-namespace.yaml
     ```
 
-2. **Create Secrets (Credentials and Config):**  
+2. **Create Secrets (Credentials and Config):**
 
    ```bash
-   # IMPORTANT: Customize these secrets before applying  
-   kubectl apply -f deploy/01-mysql-config.yaml  
-   kubectl apply -f deploy/04-ghost-config.yaml  
+   # IMPORTANT: Customize these secrets before applying
+   kubectl apply -f deploy/01-mysql-config.yaml
+   kubectl apply -f deploy/01-valkey-config.yaml
+   kubectl apply -f deploy/04-ghost-config.yaml
    kubectl apply -f deploy/01-tls.yaml
    ```
 
-3. **Create Persistent Storage and Services:**  
+3. **Create Persistent Storage and Services:**
 
    ```bash
-   kubectl apply -f deploy/02-pvc.yaml  
+   kubectl apply -f deploy/02-pvc.yaml
    kubectl apply -f deploy/03-service.yaml
    ```
 
-4. **Deploy MySQL Database (StatefulSet):**  
+4. **Deploy Database and Cache (StatefulSet and Deployment):**
 
    ```bash
-   # Wait for the MySQL PVC to be bound  
+   # Wait for the MySQL and Valkey PVCs to be bound
    kubectl apply -f deploy/05-mysql.yaml
+   kubectl apply -f deploy/05-valkey.yaml
    ```
 
-5. **Deploy the Ghost Application (Deployment):**  
+5. **Deploy the Ghost Application (Deployment):**
 
     ```bash
-    # Wait for MySQL to be ready before starting
+    # Wait for MySQL and Valkey to be ready before starting
    kubectl apply -f deploy/06-ghost-deployment.yaml
    ```
 
-6. **Expose Ghost with Ingress (Optional/Recommended):**  
+6. **Expose Ghost with Ingress (Optional/Recommended):**
 
     ```bash
     # Routes external traffic to the Ghost Service
@@ -144,9 +147,9 @@ Congratulations! You have deployed a highly secure and scalable Ghost v6 instanc
 
 To preview the website without configuring Ingress or a TLD, you can use port forwarding:
 
-1. Temporarily configure both url and admin URLs in your config.production.json Secret to use `http://localhost:2368/`.  
-2. Restart the Ghost pod(s) after updating the Secret.  
-3. Run the port-forwarding command:  
+1. Temporarily configure both url and admin URLs in your config.production.json Secret to use `http://localhost:2368/`.
+2. Restart the Ghost pod(s) after updating the Secret.
+3. Run the port-forwarding command:
 
   ```bash
   kubectl port-forward -n ghost-on-kubernetes services ghost-on-kubernetes-service 2368:2368

--- a/deploy/01-valkey-config.yaml
+++ b/deploy/01-valkey-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghost-on-kubernetes-valkey-env
+  namespace: ghost-on-kubernetes
+  labels:
+    app: ghost-on-kubernetes-valkey
+    app.kubernetes.io/name: ghost-on-kubernetes-valkey-env
+    app.kubernetes.io/instance: ghost-on-kubernetes
+    app.kubernetes.io/version: '6.0'
+    app.kubernetes.io/component: cache-secret
+    app.kubernetes.io/part-of: ghost-on-kubernetes
+type: Opaque
+stringData:
+  # Set to empty string to disable authentication, or set a strong password for production
+  VALKEY_PASSWORD: "changeme"

--- a/deploy/02-pvc.yaml
+++ b/deploy/02-pvc.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: storage
     app.kubernetes.io/part-of: ghost-on-kubernetes
-    
+
 spec:
   # Change this to your storageClassName, we suggest using a storageClassName that supports ReadWriteMany for production.
   storageClassName: ""
@@ -37,7 +37,30 @@ metadata:
     app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: database-storage
     app.kubernetes.io/part-of: ghost-on-kubernetes
-    
+
+
+spec:
+  storageClassName: "" # Change this to your storageClassName
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ghost-on-kubernetes-valkey-pvc
+  namespace: ghost-on-kubernetes
+  labels:
+    app: ghost-on-kubernetes-valkey
+    app.kubernetes.io/name: ghost-on-kubernetes-valkey-pvc
+    app.kubernetes.io/instance: ghost-on-kubernetes
+    app.kubernetes.io/version: '6.0'
+    app.kubernetes.io/component: cache-storage
+    app.kubernetes.io/part-of: ghost-on-kubernetes
 
 spec:
   storageClassName: "" # Change this to your storageClassName

--- a/deploy/03-service.yaml
+++ b/deploy/03-service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: service-frontend
     app.kubernetes.io/part-of: ghost-on-kubernetes
-    
+
 
 spec:
   ports:
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: service-database
     app.kubernetes.io/part-of: ghost-on-kubernetes
-    
+
 spec:
   ports:
   - port: 3306
@@ -46,4 +46,28 @@ spec:
   clusterIP: None
   selector:
     app: ghost-on-kubernetes-mysql
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ghost-on-kubernetes-valkey-service
+  namespace: ghost-on-kubernetes
+  labels:
+    app: ghost-on-kubernetes-valkey
+    app.kubernetes.io/name: ghost-on-kubernetes-valkey-service
+    app.kubernetes.io/instance: ghost-on-kubernetes
+    app.kubernetes.io/version: '6.0'
+    app.kubernetes.io/component: service-cache
+    app.kubernetes.io/part-of: ghost-on-kubernetes
+
+spec:
+  ports:
+  - port: 6379
+    protocol: TCP
+    targetPort: valkey
+    name: valkey
+  type: ClusterIP
+  selector:
+    app: ghost-on-kubernetes-valkey
 

--- a/deploy/04-ghost-config.yaml
+++ b/deploy/04-ghost-config.yaml
@@ -66,7 +66,9 @@ stringData:
             "port": 6379,
             "db": 0,
             "ttl": 86400,
-            "keyPrefix": "ghost:"
+            "keyPrefix": "ghost:",
+            "username": "default",
+            "password": "changeme"
           },
           "imageSizes": {
             "adapter": "Redis",

--- a/deploy/04-ghost-config.yaml
+++ b/deploy/04-ghost-config.yaml
@@ -43,13 +43,61 @@ stringData:
       },
       "database": {
         "client": "mysql",
-        "connection": 
+        "connection":
         {
           "host": "ghost-on-kubernetes-mysql-service",
           "user": "mysql-db-user",
           "password": "mysql-db-password",
           "database": "mysql-db-name",
           "port": "3306"
+        }
+      },
+      "hostSettings": {
+        "postsPublicCache": { "enabled": true },
+        "linkRedirectsPublicCache": { "enabled": true },
+        "tagsPublicCache": { "enabled": true },
+        "statsCache": { "enabled": true }
+      },
+      "adapters": {
+        "active": "Redis",
+        "cache": {
+          "Redis": {
+            "host": "ghost-on-kubernetes-valkey-service",
+            "port": 6379,
+            "db": 0,
+            "ttl": 86400,
+            "keyPrefix": "ghost:"
+          },
+          "imageSizes": {
+            "adapter": "Redis",
+            "ttl": 86400,
+            "keyPrefix": "ghost:imageSizes:"
+          },
+          "gscan": {
+            "adapter": "Redis",
+            "ttl": 43200,
+            "keyPrefix": "ghost:gscan:"
+          },
+          "postsPublic": {
+            "adapter": "Redis",
+            "ttl": 1800,
+            "keyPrefix": "ghost:postsPublic:"
+          },
+          "tagsPublic": {
+            "adapter": "Redis",
+            "ttl": 3600,
+            "keyPrefix": "ghost:tagsPublic:"
+          },
+          "linkRedirectsPublic": {
+            "adapter": "Redis",
+            "ttl": 7200,
+            "keyPrefix": "ghost:linkRedirectsPublic:"
+          },
+          "stats": {
+            "adapter": "Redis",
+            "ttl": 900,
+            "keyPrefix": "ghost:stats:"
+          }
         }
       },
       "process": "local",

--- a/deploy/05-valkey.yaml
+++ b/deploy/05-valkey.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ghost-on-kubernetes-valkey
+  namespace: ghost-on-kubernetes
+  labels:
+    app: ghost-on-kubernetes-valkey
+    app.kubernetes.io/name: ghost-on-kubernetes-valkey
+    app.kubernetes.io/instance: ghost-on-kubernetes
+    app.kubernetes.io/version: '6.0'
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: ghost-on-kubernetes
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ghost-on-kubernetes-valkey
+  template:
+    metadata:
+      labels:
+        app: ghost-on-kubernetes-valkey
+    spec:
+      initContainers:
+      - name: valkey-init
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        image: docker.io/busybox:stable-musl
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo 'Changing ownership of valkey data directory to 65532:65532'
+          chown -Rfv 65532:65532 /mnt/data || echo 'Error changing ownership of valkey data directory to 65532:65532'
+          echo 'Changing ownership of tmp mount directory to 65532:65532'
+          chown -Rfv 65532:65532 /mnt/tmp || echo 'Error changing ownership of tmp mount directory to 65532:65532'
+        volumeMounts:
+        - name: valkey-data
+          mountPath: /mnt/data
+          readOnly: false
+        - name: valkey-tmp
+          mountPath: /mnt/tmp
+          readOnly: false
+        resources:
+          requests:
+            memory: 0Mi
+            cpu: 0m
+          limits:
+            memory: 256Mi
+            cpu: 200m
+
+      containers:
+      - name: valkey
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+
+        image: docker.io/valkey/valkey:9.1-alpine
+        imagePullPolicy: Always
+        # Default Valkey images run as user 999; explicitly executing valkey-server points config data to our writable directories
+        command:
+        - valkey-server
+        - --dir
+        - /data
+        - --protected-mode
+        - "no"
+        - --requirepass
+        - $(VALKEY_PASSWORD)
+
+        # Comment the following to disable Valkey authentication
+        env:
+        - name: VALKEY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ghost-on-kubernetes-valkey-env
+              key: VALKEY_PASSWORD
+
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 100m
+          limits:
+            memory: 512Mi
+            cpu: 500m
+
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+          name: valkey
+
+        volumeMounts:
+        - name: valkey-data
+          mountPath: /data
+          readOnly: false
+        - name: valkey-tmp
+          mountPath: /tmp
+          readOnly: false
+
+      automountServiceAccountToken: false
+
+      # Optional: Uncomment the following to specify node selectors
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #             - key: node-role.kubernetes.io/worker
+      #               operator: In
+      #               values:
+      #                 - 'true'
+
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+
+      volumes:
+      - name: valkey-data
+        persistentVolumeClaim:
+          claimName: ghost-on-kubernetes-valkey-pvc
+      - name: valkey-tmp
+        emptyDir:
+          sizeLimit: 128Mi

--- a/deploy/05-valkey.yaml
+++ b/deploy/05-valkey.yaml
@@ -21,44 +21,14 @@ spec:
       labels:
         app: ghost-on-kubernetes-valkey
     spec:
-      initContainers:
-      - name: valkey-init
-        securityContext:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        image: docker.io/busybox:stable-musl
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-          echo 'Changing ownership of valkey data directory to 65532:65532'
-          chown -Rfv 65532:65532 /mnt/data || echo 'Error changing ownership of valkey data directory to 65532:65532'
-          echo 'Changing ownership of tmp mount directory to 65532:65532'
-          chown -Rfv 65532:65532 /mnt/tmp || echo 'Error changing ownership of tmp mount directory to 65532:65532'
-        volumeMounts:
-        - name: valkey-data
-          mountPath: /mnt/data
-          readOnly: false
-        - name: valkey-tmp
-          mountPath: /mnt/tmp
-          readOnly: false
-        resources:
-          requests:
-            memory: 0Mi
-            cpu: 0m
-          limits:
-            memory: 256Mi
-            cpu: 200m
-
       containers:
       - name: valkey
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 65532
+          runAsUser: 999
+          runAsGroup: 1000
 
         image: docker.io/valkey/valkey:9.1-alpine
         imagePullPolicy: Always
@@ -115,6 +85,7 @@ spec:
       #                 - 'true'
 
       securityContext:
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
 

--- a/deploy/06-ghost-deployment.yaml
+++ b/deploy/06-ghost-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/version: '6.0'
     app.kubernetes.io/component: ghost
     app.kubernetes.io/part-of: ghost-on-kubernetes
-    
-    
+
+
 spec:
   # If you want HA for your Ghost instance, you can increase the number of replicas AFTER creation and you need to adjust the storage class. See 02-pvc.yaml for more information.
   replicas: 1
@@ -140,6 +140,12 @@ spec:
         env:
         - name: NODE_ENV
           value: production
+        # Uncomment the following to enable Valkey authentication
+        # - name: VALKEY_PASSWORD
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: ghost-on-kubernetes-valkey-env
+        #       key: VALKEY_PASSWORD
         resources:
           limits:
             cpu: 800m

--- a/docs/VALKEY_SETUP.md
+++ b/docs/VALKEY_SETUP.md
@@ -1,0 +1,256 @@
+# Valkey/Redis Cache Setup Guide
+
+This guide explains how to enable and configure Valkey (or Redis) caching for your Ghost on Kubernetes deployment using the static deployment mechanism.
+
+## Overview
+
+Valkey is a high-performance in-memory data store that Ghost uses for caching. It can significantly improve your Ghost blog's performance by caching:
+
+- Post images
+- Global scans
+- Public posts
+- Public tags
+- Link redirects
+- Statistics
+
+## Files Involved
+
+When using Valkey with the static deployment, the following files are used:
+
+- `01-valkey-config.yaml` - Valkey authentication credentials
+- `02-pvc.yaml` - Persistent storage for Ghost, MySQL, and Valkey data
+- `05-valkey.yaml` - Valkey deployment
+- `03-service.yaml` - Services for Ghost, MySQL, and Valkey
+- `04-ghost-config.yaml` - Ghost configuration with cache settings
+- `06-ghost-deployment.yaml` - Ghost deployment with Valkey environment variables
+
+## Deployment Order
+
+Apply the configuration files in this order:
+
+```bash
+kubectl apply -f 00-namespace.yaml
+kubectl apply -f 01-mysql-config.yaml
+kubectl apply -f 01-valkey-config.yaml       # NEW
+kubectl apply -f 01-tls.yaml
+kubectl apply -f 02-pvc.yaml                 # Now includes Valkey PVC
+kubectl apply -f 03-service.yaml
+kubectl apply -f 04-ghost-config.yaml
+kubectl apply -f 05-mysql.yaml
+kubectl apply -f 05-valkey.yaml              # NEW
+kubectl apply -f 06-ghost-deployment.yaml
+kubectl apply -f 07-ingress.yaml
+```
+
+## Configuration
+
+### Basic Setup (No Authentication)
+
+The default configuration includes Valkey cache settings in `04-ghost-config.yaml`:
+
+```json
+"hostSettings": {
+  "postsPublicCache": { "enabled": true },
+  "linkRedirectsPublicCache": { "enabled": true },
+  "tagsPublicCache": { "enabled": true },
+  "statsCache": { "enabled": true }
+},
+"adapters": {
+  "active": "Redis",
+  "cache": {
+    "Redis": {
+      "host": "ghost-on-kubernetes-valkey-service",
+      "port": 6379,
+      "db": 0,
+      "ttl": 86400,
+      "keyPrefix": "ghost:"
+    },
+    ...
+  }
+}
+```
+
+### Enabling Valkey Authentication
+
+If you want to use authentication with Valkey:
+
+1. **Set a strong password** in `01-valkey-config.yaml`:
+   ```yaml
+   stringData:
+     VALKEY_PASSWORD: "your-strong-password-here"
+   ```
+
+2. **Uncomment Valkey authentication** in `05-valkey.yaml`:
+     - valkey-server
+     - --dir
+     - /data
+     - --protected-mode
+     - "no"
+     - --requirepass           # Uncomment
+     - $(VALKEY_PASSWORD)      # Uncomment
+
+   env:
+     - name: VALKEY_PASSWORD
+       valueFrom:
+         secretKeyRef:
+           name: ghost-on-kubernetes-valkey-env
+           key: VALKEY_PASSWORD
+   ```
+
+3. **Update Ghost deployment** in `06-ghost-deployment.yaml` to include the password:
+   ```yaml
+   env:
+     - name: NODE_ENV
+       value: production
+     - name: VALKEY_PASSWORD
+       valueFrom:
+         secretKeyRef:
+           name: ghost-on-kubernetes-valkey-env
+           key: VALKEY_PASSWORD
+   ```
+
+4. **Update Ghost config** in `04-ghost-config.yaml` to include credentials:
+   ```json
+   "Redis": {
+     "host": "ghost-on-kubernetes-valkey-service",
+     "port": 6379,
+     "db": 0,
+     "ttl": 86400,
+     "keyPrefix": "ghost:",
+     "username": "default",
+     "password": "your-strong-password-here"
+   }
+   ```
+
+## TTL (Time To Live) Values
+
+The cache TTL values (in seconds) control how long items are cached:
+
+- `imageSizes`: 86400 (1 day)
+- `gscan`: 43200 (12 hours)
+- `postsPublic`: 1800 (30 minutes)
+- `tagsPublic`: 3600 (1 hour)
+- `linkRedirectsPublic`: 7200 (2 hours)
+- `stats`: 900 (15 minutes)
+
+Adjust these values in `04-ghost-config.yaml` based on your needs.
+
+## Using External Valkey/Redis
+
+If you want to use an external Redis or Valkey instance instead of deploying one:
+
+1. **Skip files**: Do not apply `08-valkey-config.yaml`, `09-valkey-pvc.yaml`, and `10-valkey.yaml`
+
+2. **Do not apply the Valkey service**: Comment out or remove the Valkey service section from `03-service.yaml`
+
+3. **Update `04-ghost-config.yaml`** with your external Valkey/Redis details:
+   ```json
+   "Redis": {
+     "host": "your-external-valkey-host",
+     "port": 6379,
+     "db": 0,
+     "ttl": 86400,
+     "keyPrefix": "ghost:",
+     "username": "your-username",
+     "password": "your-password"
+   }
+   ```
+
+## Example Configurations
+
+Two example configuration files are provided:
+
+- `examples/config.production-valkey.sample.yaml` - Production configuration with Valkey
+- `examples/config.development-valkey.sample.yaml` - Development configuration with Valkey
+
+These can be used as templates for your deployments.
+
+## Storage Requirements
+
+Valkey persistence is configured with:
+
+- **Storage Class**: Default (modify `09-valkey-pvc.yaml` if needed)
+- **Size**: 1Gi (adjust based on your cache needs)
+- **Access Mode**: ReadWriteOnce
+
+For development, 1Gi is usually sufficient. Adjust for production based on your blog size and traffic.
+
+## Resource Limits
+
+Default Valkey resource limits in `10-valkey.yaml`:
+
+```yaml
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 100m
+  limits:
+    memory: 512Mi
+    cpu: 500m
+```
+
+Adjust these based on your deployment size and available cluster resources.
+
+## Troubleshooting
+
+### Valkey Pod Won't Start
+
+1. Check Valkey pod logs:
+   ```bash
+   kubectl logs -f deployment/ghost-on-kubernetes-valkey -n ghost-on-kubernetes
+   ```
+
+2. Verify PVC is created:
+   ```bash
+   kubectl get pvc -n ghost-on-kubernetes | grep valkey
+   ```
+
+3. Check events:
+   ```bash
+   kubectl describe pod <valkey-pod-name> -n ghost-on-kubernetes
+   ```
+
+### Ghost Can't Connect to Valkey
+
+1. Verify Valkey service is running:
+   ```bash
+   kubectl get svc -n ghost-on-kubernetes | grep valkey
+   ```
+
+2. Test connectivity from Ghost pod:
+   ```bash
+   kubectl exec -it <ghost-pod-name> -n ghost-on-kubernetes -- sh
+   # Inside the pod:
+   nc -zv ghost-on-kubernetes-valkey-service 6379
+   ```
+
+3. Check Ghost logs:
+   ```bash
+   kubectl logs -f deployment/ghost-on-kubernetes -n ghost-on-kubernetes
+   ```
+
+### Cache Not Working
+
+1. Verify Ghost config is loaded correctly:
+   ```bash
+   kubectl exec -it <ghost-pod-name> -n ghost-on-kubernetes -- cat /home/nonroot/app/ghost/config.production.json
+   ```
+
+2. Check for cache-related errors in Ghost logs
+
+3. Verify Valkey contains data:
+   ```bash
+   kubectl exec -it <valkey-pod-name> -n ghost-on-kubernetes -- valkey-cli
+   # Inside valkey-cli:
+   > KEYS ghost:*
+   > INFO stats
+   ```
+
+## Next Steps
+
+After deploying Valkey, you can:
+
+1. Monitor cache performance in Ghost admin
+2. Adjust TTL values based on your content update frequency
+3. Scale Valkey resources if needed
+4. Consider adding Valkey monitoring/alerting with Prometheus

--- a/examples/config.development-caching.sample.yaml
+++ b/examples/config.development-caching.sample.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghost-config-dev
+  namespace: ghost-on-kubernetes
+type: Opaque
+stringData:
+  config.development.json: |-
+    {
+      "url": "http://localhost:2368",
+      "admin": {
+        "url": "http://localhost:2368"
+      },
+      "server": {
+        "port": 2368,
+        "host": "0.0.0.0"
+      },
+      "mail": {
+        "transport": "Direct"
+      },
+      "logging": {
+        "transports": [
+          "stdout"
+        ]
+      },
+      "database": {
+        "client": "mysql",
+        "connection":
+        {
+          "host": "ghost-on-kubernetes-mysql-service",
+          "user": "mysql-db-user",
+          "password": "mysql-db-password",
+          "database": "mysql-db-name",
+          "port": "3306"
+        }
+      },
+      "hostSettings": {
+        "postsPublicCache": { "enabled": true },
+        "linkRedirectsPublicCache": { "enabled": true },
+        "tagsPublicCache": { "enabled": true },
+        "statsCache": { "enabled": true }
+      },
+      "adapters": {
+        "active": "Redis",
+        "cache": {
+          "Redis": {
+            "host": "ghost-on-kubernetes-valkey-service",
+            "port": 6379,
+            "db": 0,
+            "ttl": 86400,
+            "keyPrefix": "ghost:"
+          },
+          "imageSizes": {
+            "adapter": "Redis",
+            "ttl": 86400,
+            "keyPrefix": "ghost:imageSizes:"
+          },
+          "gscan": {
+            "adapter": "Redis",
+            "ttl": 43200,
+            "keyPrefix": "ghost:gscan:"
+          },
+          "postsPublic": {
+            "adapter": "Redis",
+            "ttl": 1800,
+            "keyPrefix": "ghost:postsPublic:"
+          },
+          "tagsPublic": {
+            "adapter": "Redis",
+            "ttl": 3600,
+            "keyPrefix": "ghost:tagsPublic:"
+          },
+          "linkRedirectsPublic": {
+            "adapter": "Redis",
+            "ttl": 7200,
+            "keyPrefix": "ghost:linkRedirectsPublic:"
+          },
+          "stats": {
+            "adapter": "Redis",
+            "ttl": 900,
+            "keyPrefix": "ghost:stats:"
+          }
+        }
+      },
+      "process": "local",
+      "paths": {
+        "contentPath": "/home/nonroot/app/ghost/content"
+      }
+    }

--- a/examples/config.production-caching.sample.yaml
+++ b/examples/config.production-caching.sample.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghost-config-prod
+  namespace: ghost-on-kubernetes
+type: Opaque
+stringData:
+  config.production.json: |-
+    {
+      "url": "https://yourdomain.tld",
+      "admin": {
+        "url": "https://yourdomain.tld"
+      },
+      "server": {
+        "port": 2368,
+        "host": "0.0.0.0"
+      },
+      "mail": {
+        "transport": "SMTP",
+        "from": "user@server.com",
+        "options": {
+          "service": "Google",
+          "host": "smtp.gmail.com",
+          "port": 465,
+          "secure": true,
+          "auth": {
+            "user": "user@server.com",
+            "pass": "passsword"
+          }
+        }
+      },
+      "logging": {
+        "transports": [
+          "stdout"
+        ]
+      },
+      "database": {
+        "client": "mysql",
+        "connection":
+        {
+          "host": "ghost-on-kubernetes-mysql-service",
+          "user": "mysql-db-user",
+          "password": "mysql-db-password",
+          "database": "mysql-db-name",
+          "port": "3306"
+        }
+      },
+      "hostSettings": {
+        "postsPublicCache": { "enabled": true },
+        "linkRedirectsPublicCache": { "enabled": true },
+        "tagsPublicCache": { "enabled": true },
+        "statsCache": { "enabled": true }
+      },
+      "adapters": {
+        "active": "Redis",
+        "cache": {
+          "Redis": {
+            "host": "ghost-on-kubernetes-valkey-service",
+            "port": 6379,
+            "db": 0,
+            "ttl": 86400,
+            "keyPrefix": "ghost:"
+          },
+          "imageSizes": {
+            "adapter": "Redis",
+            "ttl": 86400,
+            "keyPrefix": "ghost:imageSizes:"
+          },
+          "gscan": {
+            "adapter": "Redis",
+            "ttl": 43200,
+            "keyPrefix": "ghost:gscan:"
+          },
+          "postsPublic": {
+            "adapter": "Redis",
+            "ttl": 1800,
+            "keyPrefix": "ghost:postsPublic:"
+          },
+          "tagsPublic": {
+            "adapter": "Redis",
+            "ttl": 3600,
+            "keyPrefix": "ghost:tagsPublic:"
+          },
+          "linkRedirectsPublic": {
+            "adapter": "Redis",
+            "ttl": 7200,
+            "keyPrefix": "ghost:linkRedirectsPublic:"
+          },
+          "stats": {
+            "adapter": "Redis",
+            "ttl": 900,
+            "keyPrefix": "ghost:stats:"
+          }
+        }
+      },
+      "process": "local",
+      "paths": {
+        "contentPath": "/home/nonroot/app/ghost/content"
+      }
+    }


### PR DESCRIPTION
This PR adds comprehensive application-level caching support to Ghost using Valkey/Redis. By mapping and injecting undocumented root-level hostSettings flags, this change unlocks Ghost’s native, multi-tier cache adapter framework for key application subsystems. See issue #741 for more info

## Core Changes

### Helm Chart Enhancements

* Added a dynamic configuration loop to activate caching for postsPublic, tagsPublic, linkRedirectsPublic, and stats.
* Implemented isolated keyspace tracking (e.g., ghost:postsPublic:[hash]) using a trimSuffix helper to cleanly normalize trailing delimiters.
* Introduced an optional, secure, non-root internal Valkey deployment with persistence support.
* Validated full compatibility with external, multi-tenant Valkey clusters.

### Static/Standalone Support:

* Updated the repository documentation to map out raw config.production.json configurations and explicit prefix-handling guidelines for non-Helm installations.
* Added example valkey deployment configs

## Testing Completed

The following deployment scenarios were fully verified under active load, with keyspace structure validated via valkey-cli:

* Ghost with helm without Valkey (Stock operation)
* Ghost with helm with internal Valkey (PVC persistence and secure non-root runtime)
* Ghost with helm with external Valkey (Multi-tenant prefix validation)
* Ghost with static deployment without Valkey (Stock operation)
* Ghost with static deployment with Valkey (PVC persistence and secure non-root runtime)

## Gaps & Edge Cases

* Exclusion of settings Cache: Testing revealed that routing the cache:settings adapter causes a container boot panic loop due to a missing database-fallback routine on fresh cache misses. It has been intentionally omitted from the adapter loop to preserve stability.
* Database Selector Behavior: Upstream client constraints cause Ghost to ignore custom database indexes, forcing all operations onto database 0. Multi-tenant safety is managed strictly via the automated prefix isolation verified in this PR. (due in a future release)
* Spanish translation: The Spanish version of the README hasn't been updated, my Spanish isn't any good