### PR TITLE
Add Helm deployment instructions to README

### DIFF
--- a/Charts/ghost-on-kubernetes/Chart.yaml
+++ b/Charts/ghost-on-kubernetes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost-on-kubernetes
 description: Deploy the leading open-source publishing platform, Ghost, on Kubernetes and Docker with maximum security and efficiency using a hardened, multi-arch container image.
 type: application
-version: "1.0.9"
+version: "1.1.1"
 appVersion: "6.44.1"
 keywords:
   - ghost

--- a/Charts/ghost-on-kubernetes/README.md
+++ b/Charts/ghost-on-kubernetes/README.md
@@ -107,6 +107,7 @@ helm install my-ghost ./ghost-on-kubernetes \
   --set valkey.auth.enabled=true \
   --set valkey.auth.password=your-password \
   --set persistence.valkey.storageClassName=your-storage-class
+```
 
 ### With cert-manager for TLS
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,24 @@ Follow these steps to deploy Ghost on your Kubernetes cluster.
 1. A functioning Kubernetes cluster (kubectl configured).
 2. A provisioned StorageClass (required for PVCs).
 
-### **0. Clone (or fork) the Repository**
+### **0. Option 1: Deploy with Helm**
+
+Alternatively, you can install the chart from our Helm repository (recommended):
+
+Detailed values and configurations available within [Chart readme](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Charts/ghost-on-kubernetes/README.md) and [Chart values examples](https://github.com/sredevopsorg/ghost-on-kubernetes/blob/main/Charts/ghost-on-kubernetes/examples)
+
+```bash
+helm repo add sredevopsorg https://sredevopsorg.github.io/ghost-on-kubernetes
+helm repo update
+helm install my-ghost sredevopsorg/ghost-on-kubernetes \
+  --namespace ghost \
+  --create-namespace \
+  --set ghost.url=https://yourdomain.tld \
+  --set persistence.ghost.storageClassName=your-storage-class
+```
+
+
+### **0. Option 2: Clone (or fork) the Repository**
 
 ```bash
 ## Clone the repository
@@ -81,18 +98,6 @@ Review the example configuration files and modify the manifests in the deploy/ f
 ### **2. Deployment Sequence**
 
 It is **crucial** to apply the manifests in the correct order to ensure dependency resolution (especially the database components).
-
-Alternatively, you can install the chart from our Helm repository (recommended):
-
-```bash
-helm repo add sredevopsorg https://sredevopsorg.github.io/ghost-on-kubernetes
-helm repo update
-helm install my-ghost sredevopsorg/ghost-on-kubernetes \
-  --namespace ghost \
-  --create-namespace \
-  --set ghost.url=https://yourdomain.tld \
-  --set persistence.ghost.storageClassName=your-storage-class
-```
 
 1. **Create the Namespace:**
 


### PR DESCRIPTION
Updated README to include Helm deployment options and removed redundant instructions.